### PR TITLE
fix: harden malformed media inputs

### DIFF
--- a/Primuse/App/CarPlaySceneDelegate.swift
+++ b/Primuse/App/CarPlaySceneDelegate.swift
@@ -511,7 +511,7 @@ extension CarPlaySceneDelegate {
             return a < b
         }
         return sortedKeys.map { letter in
-            let sectionItems = grouped[letter]!.map(makeItem)
+            let sectionItems = (grouped[letter] ?? []).map(makeItem)
             return CPListSection(items: sectionItems, header: letter, sectionIndexTitle: letter)
         }
     }

--- a/Primuse/Services/Audio/AudioCacheManager.swift
+++ b/Primuse/Services/Audio/AudioCacheManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PrimuseKit
 
 enum OfflineAudioCacheState: String, Codable, Sendable, Equatable {
     case notCached
@@ -48,7 +49,7 @@ actor AudioCacheManager {
     }
 
     private init() {
-        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let caches = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
         basePath = caches.appendingPathComponent("primuse_audio_cache")
         logURL = basePath.appendingPathComponent(".access_log.json")
         manifestURL = basePath.appendingPathComponent(".offline_manifest.json")

--- a/Primuse/Services/Audio/AudioPlayerService.swift
+++ b/Primuse/Services/Audio/AudioPlayerService.swift
@@ -3275,7 +3275,7 @@ final class AudioPlayerService {
         nextURL: URL,
         nextDecoderKind: DecoderKind
     ) {
-        let totalSteps = max(1, Int(duration / 0.05))
+        let totalSteps = max(1, (duration / 0.05).finiteInt(or: 1))
         let stepCounter = StepCounter()
         let rampPlayID = playID
 
@@ -4179,8 +4179,8 @@ final class AudioPlayerService {
             state.albumTitle ?? "",
             state.coverImageName ?? "",
             state.isPlaying ? "1" : "0",
-            String(Int(state.currentTime.rounded())),
-            String(Int(state.duration.rounded()))
+            String(state.currentTime.rounded().finiteInt()),
+            String(state.duration.rounded().finiteInt())
         ].joined(separator: "|")
     }
 }

--- a/Primuse/Services/Audio/CloudPlaybackSource.swift
+++ b/Primuse/Services/Audio/CloudPlaybackSource.swift
@@ -335,11 +335,11 @@ private final class HTTPRangeFetcher: @unchecked Sendable {
     }
 
     func fetch(offset: Int64, length: Int64) async throws -> Data {
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        let rangeHeader = offset < 0
-            ? "bytes=\(offset)"
-            : "bytes=\(offset)-\(offset + length - 1)"
         request.setValue(rangeHeader, forHTTPHeaderField: "Range")
         request.timeoutInterval = 60
 
@@ -490,6 +490,10 @@ private final class State: @unchecked Sendable {
         errorOut: AutoreleasingUnsafeMutablePointer<NSError?>?
     ) -> Data? {
         if offset >= totalLength { return Data() }
+        guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: offset, length: length) else {
+            errorOut?.pointee = NSError(domain: NSPOSIXErrorDomain, code: Int(EINVAL))
+            return nil
+        }
         if isClosed() {
             errorOut?.pointee = NSError(
                 domain: NSPOSIXErrorDomain,
@@ -498,7 +502,7 @@ private final class State: @unchecked Sendable {
             )
             return nil
         }
-        let endOffset = min(offset + length, totalLength)
+        let endOffset = min(requestedEnd, totalLength)
 
         let served: Data?
 
@@ -886,18 +890,19 @@ private final class State: @unchecked Sendable {
     }
 
     private func readFromCacheIfAvailable(offset: Int64, endOffset: Int64) -> Data? {
+        guard offset >= 0, endOffset >= offset else { return nil }
         lock.lock()
         let coveringRange = cachedRanges.first { $0.contains(offset) }
         let url = activeURL
         lock.unlock()
         guard let coveringRange else { return nil }
         let upper = min(endOffset, coveringRange.upperBound)
-        guard upper > offset else { return nil }
+        guard upper > offset, let readLength = Int(exactly: upper - offset) else { return nil }
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
         do {
             try handle.seek(toOffset: UInt64(offset))
-            return try handle.read(upToCount: Int(upper - offset))
+            return try handle.read(upToCount: readLength)
         } catch {
             return nil
         }
@@ -919,7 +924,9 @@ private final class State: @unchecked Sendable {
         }
 
         lock.lock()
-        mergeRange(offset..<offset + Int64(data.count))
+        if let end = SafeByteRange.exclusiveEnd(offset: offset, length: Int64(data.count)) {
+            mergeRange(offset..<end)
+        }
         // Once the entire file is covered AND we're allowed to persist,
         // rename .partial → final so the canonical cache path is only
         // ever populated when truly complete. Future plays of this song

--- a/Primuse/Services/Audio/MusicVideoStreamingLoader.swift
+++ b/Primuse/Services/Audio/MusicVideoStreamingLoader.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import PrimuseKit
 import UniformTypeIdentifiers
 
 /// resolveVideoAsset 的返回形态: 直链/本地文件给 AVPlayer(url:),
@@ -98,9 +99,18 @@ final class MusicVideoStreamingLoader: NSObject, @unchecked Sendable {
         }
 
         var offset = dataRequest.requestedOffset
-        let end: Int64 = dataRequest.requestsAllDataToEndOfResource
-            ? contentLength
-            : min(contentLength, offset + Int64(dataRequest.requestedLength))
+        let end: Int64
+        if dataRequest.requestsAllDataToEndOfResource {
+            end = contentLength
+        } else if let requestedEnd = SafeByteRange.exclusiveEnd(
+            offset: offset,
+            length: Int64(dataRequest.requestedLength)
+        ) {
+            end = min(contentLength, requestedEnd)
+        } else {
+            finish(box, error: CocoaError(.fileReadInvalidFileName))
+            return
+        }
 
         do {
             while offset < end {
@@ -130,9 +140,13 @@ final class MusicVideoStreamingLoader: NSObject, @unchecked Sendable {
     /// 长度覆盖请求区间即可信; 下载完成瞬间 partial 被 move 成 target,
     /// 读失败自然落到下一候选或网络直取。
     private func readLocalRange(offset: Int64, length: Int) -> Data? {
+        guard length >= 0,
+              let end = SafeByteRange.exclusiveEnd(offset: offset, length: Int64(length)) else {
+            return nil
+        }
         for candidate in [cacheTarget, cachePartial] {
             guard let size = (try? FileManager.default.attributesOfItem(atPath: candidate.path)[.size]) as? Int64,
-                  size >= offset + Int64(length),
+                  size >= end,
                   let handle = try? FileHandle(forReadingFrom: candidate) else { continue }
             defer { try? handle.close() }
             guard (try? handle.seek(toOffset: UInt64(offset))) != nil,

--- a/Primuse/Services/Cloud/CloudKitSyncService.swift
+++ b/Primuse/Services/Cloud/CloudKitSyncService.swift
@@ -177,7 +177,7 @@ final class CloudKitSyncService {
         self.sourcesStore = sourcesStore
         self.scraperConfigStore = scraperConfigStore
         self.scraperSettingsStore = scraperSettingsStore
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = FileManager.default.primuseDirectoryURL(for: .applicationSupportDirectory)
         let directory = appSupport.appendingPathComponent("Primuse", isDirectory: true)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         self.stateURL = directory.appendingPathComponent("cloudkit-engine-state.bin")

--- a/Primuse/Services/Cloud/LibrarySnapshotSync.swift
+++ b/Primuse/Services/Cloud/LibrarySnapshotSync.swift
@@ -31,9 +31,9 @@ final class LibrarySnapshotSync: Sendable {
         // tvOS 只允许写 Caches / tmp,Application Support 不可创建/写入,会导致
         // 快照写盘失败("No such file or directory")。tvOS 改用 Caches。
         #if os(tvOS)
-        let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let base = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
         #else
-        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let base = FileManager.default.primuseDirectoryURL(for: .applicationSupportDirectory)
         #endif
         return base.appendingPathComponent("Primuse", isDirectory: true)
     }

--- a/Primuse/Services/DLNA/DLNARendererService.swift
+++ b/Primuse/Services/DLNA/DLNARendererService.swift
@@ -872,8 +872,9 @@ final class DLNARendererService {
                 let value = line.split(separator: ":", maxSplits: 1).last ?? ""
                 return Int(value.trimmingCharacters(in: .whitespaces))
             } ?? 0
-        let totalLength = headerEnd + contentLength
-        guard data.count >= totalLength else { return nil }
+        guard contentLength >= 0 else { return nil }
+        let (totalLength, overflow) = headerEnd.addingReportingOverflow(contentLength)
+        guard !overflow, totalLength >= headerEnd, data.count >= totalLength else { return nil }
         return String(data: data.prefix(totalLength), encoding: .utf8)
     }
 
@@ -921,7 +922,7 @@ final class DLNARendererService {
 
     private var renderingVolumePercent: Int {
         let volume = rendererMuted ? lastNonMutedVolume : player.audioEngine.volume
-        return max(0, min(100, Int((volume * 100).rounded())))
+        return max(0, min(100, Double(volume * 100).rounded().finiteInt()))
     }
 
     private func setRenderingVolumePercent(_ percent: Int) {
@@ -2811,6 +2812,7 @@ final class DLNAMediaServer {
 
     /// "Range: bytes=0-1024" / "bytes=500-" / "bytes=-200" 三种形式。
     private func parseByteRange(_ value: String, totalSize: Int) -> (Int, Int)? {
+        guard totalSize > 0 else { return nil }
         let prefix = "bytes="
         guard let rangeStart = value.range(of: prefix) else { return nil }
         let after = value[rangeStart.upperBound...]
@@ -2820,15 +2822,15 @@ final class DLNAMediaServer {
         let endStr = parts[1].trimmingCharacters(in: .whitespaces)
         if startStr.isEmpty {
             // "-200" → 最后 200 字节
-            guard let suffix = Int(endStr) else { return nil }
-            let start = max(0, totalSize - suffix)
+            guard let suffix = Int(endStr), suffix > 0 else { return nil }
+            let start = suffix >= totalSize ? 0 : totalSize - suffix
             return (start, totalSize - 1)
         }
-        guard let start = Int(startStr) else { return nil }
+        guard let start = Int(startStr), start >= 0, start < totalSize else { return nil }
         if endStr.isEmpty {
             return (start, totalSize - 1)
         }
-        guard let end = Int(endStr) else { return nil }
+        guard let end = Int(endStr), end >= start else { return nil }
         return (start, min(end, totalSize - 1))
     }
 

--- a/Primuse/Services/Library/DuplicateDetector.swift
+++ b/Primuse/Services/Library/DuplicateDetector.swift
@@ -29,7 +29,7 @@ enum DuplicateDetector {
             DuplicateKey(
                 title: normalize(song.title),
                 artist: normalize(song.artistName ?? ""),
-                durationBucket: Int(song.duration) / durationBucketSec
+                durationBucket: song.duration.finiteInt() / durationBucketSec
             )
         }
 
@@ -39,12 +39,13 @@ enum DuplicateDetector {
                 // 标题或艺术家是空的 group 没意义 (会把所有 "未知" 归为一组)
                 guard !key.title.isEmpty else { return nil }
                 let sorted = members.sorted { qualityScore(of: $0) > qualityScore(of: $1) }
-                let displaySong = sorted.first!
+                guard let displaySong = sorted.first else { return nil }
                 return DuplicateGroup(
                     id: "\(key.title)|\(key.artist)|\(key.durationBucket)",
                     title: displaySong.title,
                     artist: displaySong.artistName ?? "",
                     duration: displaySong.duration,
+                    bestSong: displaySong,
                     songs: sorted
                 )
             }
@@ -93,10 +94,10 @@ struct DuplicateGroup: Identifiable, Sendable {
     let title: String
     let artist: String
     let duration: TimeInterval
+    let bestSong: Song
     /// 按质量评分降序排列, 第一个是推荐保留的。
     let songs: [Song]
 
-    var bestSong: Song { songs.first! }
     var redundantSongs: [Song] { Array(songs.dropFirst()) }
     var count: Int { songs.count }
 }

--- a/Primuse/Services/Library/LibraryDatabase.swift
+++ b/Primuse/Services/Library/LibraryDatabase.swift
@@ -7,7 +7,7 @@ actor LibraryDatabase {
 
     static func create() async throws -> LibraryDatabase {
         let fileManager = FileManager.default
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = fileManager.primuseDirectoryURL(for: .applicationSupportDirectory)
         let dbDirectory = appSupport.appendingPathComponent("Primuse", isDirectory: true)
         try fileManager.createDirectory(at: dbDirectory, withIntermediateDirectories: true)
 

--- a/Primuse/Services/Library/MetadataBackfillService.swift
+++ b/Primuse/Services/Library/MetadataBackfillService.swift
@@ -140,7 +140,7 @@ final class MetadataBackfillService {
         self.library = library
         self.sourceManager = sourceManager
         self.backfillableSourceIDs = backfillableSourceIDs
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = FileManager.default.primuseDirectoryURL(for: .applicationSupportDirectory)
         let directory = appSupport.appendingPathComponent("Primuse", isDirectory: true)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         self.failedURL = directory.appendingPathComponent("backfill-failed.json")
@@ -952,7 +952,7 @@ final class MetadataBackfillService {
         let seconds: TimeInterval
 
         var errorDescription: String? {
-            "Timed out reading tags after \(Int(seconds))s"
+            "Timed out reading tags after \(seconds.finiteInt())s"
         }
     }
 
@@ -1017,7 +1017,8 @@ final class MetadataBackfillService {
     ) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in
             let box = AsyncTimeoutBox<T>(continuation)
-            let timeoutNanoseconds = UInt64(max(0.1, seconds) * 1_000_000_000)
+            let timeoutNanoseconds = (max(0.1, seconds) * 1_000_000_000)
+                .finiteUInt64(or: 100_000_000)
 
             let workTask = Task {
                 do {
@@ -1165,7 +1166,9 @@ final class MetadataBackfillService {
                   (metadata.bitRate ?? 0) <= 0,
                   metadata.duration > 0,
                   song.fileSize > 0 {
-            metadata.bitRate = Int((Double(song.fileSize) * 8.0 / metadata.duration / 1000.0).rounded())
+            metadata.bitRate = (Double(song.fileSize) * 8.0 / metadata.duration / 1000.0)
+                .rounded()
+                .finiteInt()
         }
         let merged = mergeSong(bare: song, metadata: metadata)
         let artworkStillMissing = Self.needsEmbeddedArtworkBackfill(song)

--- a/Primuse/Services/Library/MusicLibrary.swift
+++ b/Primuse/Services/Library/MusicLibrary.swift
@@ -388,7 +388,10 @@ enum MusicDiscoveryEngine {
         // String.folding / 路径拆分。先把每首歌的比较特征归一化一次，
         // 后续 candidate × seed 只做普通值比较。
         let normalizedSongs = songs.map(NormalizedSong.init)
-        let byID = Dictionary(uniqueKeysWithValues: normalizedSongs.map { ($0.song.id, $0) })
+        let byID = Dictionary(
+            normalizedSongs.map { ($0.song.id, $0) },
+            uniquingKeysWith: { current, _ in current }
+        )
         let seeds = input.seedIDs.compactMap { byID[$0] }
 
         guard !seeds.isEmpty else {
@@ -966,9 +969,9 @@ final class MusicLibrary {
     init(fileManager: FileManager = .default) {
         // tvOS 只允许写 Caches / tmp;须与 LibrarySnapshotSync / SourcesStore 同目录。
         #if os(tvOS)
-        let appSupport = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let appSupport = fileManager.primuseDirectoryURL(for: .cachesDirectory)
         #else
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = fileManager.primuseDirectoryURL(for: .applicationSupportDirectory)
         #endif
         let directory = appSupport.appendingPathComponent("Primuse", isDirectory: true)
         try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -1877,7 +1880,10 @@ final class MusicLibrary {
     ) -> [PendingSongIdentity] {
         let now = Date()
         let cutoff = now.addingTimeInterval(-Self.pendingIdentityTTL)
-        let existingByIdentity = Dictionary(uniqueKeysWithValues: existing.map { ($0.identity, $0) })
+        let existingByIdentity = Dictionary(
+            existing.map { ($0.identity, $0) },
+            uniquingKeysWith: { lhs, rhs in lhs.firstSeenAt <= rhs.firstSeenAt ? lhs : rhs }
+        )
         var result: [PendingSongIdentity] = []
         var seen = Set<SongIdentity>()
         for identity in fresh {

--- a/Primuse/Services/Library/PlayHistoryStore.swift
+++ b/Primuse/Services/Library/PlayHistoryStore.swift
@@ -56,7 +56,7 @@ final class PlayHistoryStore {
     private var currentMaxElapsed: TimeInterval = 0
 
     private init() {
-        let docs = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let docs = FileManager.default.primuseDirectoryURL(for: .applicationSupportDirectory)
             .appendingPathComponent("Primuse", isDirectory: true)
         try? FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
         self.storeURL = docs.appendingPathComponent("play_history.json")
@@ -127,7 +127,10 @@ final class PlayHistoryStore {
     func mergeRemoteEntries(_ remoteEntries: [Entry]) {
         guard !remoteEntries.isEmpty else { return }
         let before = Set(entries.map(\.id))
-        var mergedByID = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+        var mergedByID = Dictionary(
+            entries.map { ($0.id, $0) },
+            uniquingKeysWith: { lhs, rhs in lhs.playedAt >= rhs.playedAt ? lhs : rhs }
+        )
         for entry in remoteEntries {
             mergedByID[entry.id] = entry
         }
@@ -193,8 +196,8 @@ final class PlayHistoryStore {
         let scoped = entries(in: range)
         let groups = Dictionary(grouping: scoped) { $0.songID }
         return groups
-            .map { (songID, plays) -> RankedItem in
-                let first = plays.first!
+            .compactMap { (songID, plays) -> RankedItem? in
+                guard let first = plays.first else { return nil }
                 return RankedItem(
                     id: songID,
                     title: first.songTitle,
@@ -233,8 +236,8 @@ final class PlayHistoryStore {
         let scoped = entries(in: range).filter { !$0.albumTitle.isEmpty }
         let groups = Dictionary(grouping: scoped) { "\($0.albumTitle)|\($0.artistName)" }
         return groups
-            .map { (key, plays) -> RankedItem in
-                let first = plays.first!
+            .compactMap { (key, plays) -> RankedItem? in
+                guard let first = plays.first else { return nil }
                 return RankedItem(
                     id: "album:\(key)",
                     title: first.albumTitle,

--- a/Primuse/Services/Library/ScanService.swift
+++ b/Primuse/Services/Library/ScanService.swift
@@ -75,7 +75,7 @@ final class ScanService {
     private let decoder = JSONDecoder()
 
     init(fileManager: FileManager = .default) {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = fileManager.primuseDirectoryURL(for: .applicationSupportDirectory)
         let directory = appSupport.appendingPathComponent("Primuse", isDirectory: true)
         try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
         checkpointURL = directory.appendingPathComponent("scan-checkpoints.json")

--- a/Primuse/Services/Library/SmartPlaylistEngine.swift
+++ b/Primuse/Services/Library/SmartPlaylistEngine.swift
@@ -266,7 +266,9 @@ enum SmartPlaylistEngine {
     }()
 
     private static func parseDate(_ text: String) -> Date? {
-        if text.hasPrefix("days:"), let days = Int(text.dropFirst("days:".count)) {
+        if text.hasPrefix("days:"),
+           let days = Int(text.dropFirst("days:".count)),
+           days >= 0 {
             return Calendar.current.date(byAdding: .day, value: -days, to: Date())
         }
         if let d = isoFormatter.date(from: text) { return d }
@@ -282,6 +284,7 @@ enum SmartPlaylistEngine {
         smart: SmartPlaylist,
         history: PlayHistoryStore
     ) -> [Song] {
+        let safeLimit = max(0, smart.limit ?? Int.max)
         let sorted: [Song]
         switch smart.sortField {
         case .title:
@@ -302,12 +305,12 @@ enum SmartPlaylistEngine {
             sorted = songs.sorted { (lookup[$0.id] ?? 0) < (lookup[$1.id] ?? 0) }
         case .random:
             // random 模式忽略 direction (用户既然要随机就别再纠结升降序)
-            return Array(songs.shuffled().prefix(smart.limit ?? Int.max))
+            return Array(songs.shuffled().prefix(safeLimit))
         }
 
         let directional = smart.sortDirection == .descending ? Array(sorted.reversed()) : sorted
-        if let limit = smart.limit, directional.count > limit {
-            return Array(directional.prefix(limit))
+        if directional.count > safeLimit {
+            return Array(directional.prefix(safeLimit))
         }
         return directional
     }

--- a/Primuse/Services/Lyrics/LyricsTranslationCache.swift
+++ b/Primuse/Services/Lyrics/LyricsTranslationCache.swift
@@ -34,7 +34,7 @@ final class LyricsTranslationCache {
 
     private init() {
         let appSupport = FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .primuseDirectoryURL(for: .applicationSupportDirectory)
         let dir = appSupport.appendingPathComponent("Primuse/LyricsTranslation", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.fileURL = dir.appendingPathComponent("cache.json")

--- a/Primuse/Services/Metadata/FileMetadataReader.swift
+++ b/Primuse/Services/Metadata/FileMetadataReader.swift
@@ -601,14 +601,14 @@ enum FileMetadataReader {
     }
 
     private static func readUInt24BE(_ data: Data, at offset: Int) -> Int {
-        guard offset + 3 <= data.count else { return 0 }
+        guard offset >= 0, offset <= data.count - 3 else { return 0 }
         return (Int(data[offset]) << 16)
             | (Int(data[offset + 1]) << 8)
             | Int(data[offset + 2])
     }
 
     private static func readUInt32BE(_ data: Data, at offset: Int) -> Int {
-        guard offset + 4 <= data.count else { return 0 }
+        guard offset >= 0, offset <= data.count - 4 else { return 0 }
         return (Int(data[offset]) << 24)
             | (Int(data[offset + 1]) << 16)
             | (Int(data[offset + 2]) << 8)
@@ -616,7 +616,7 @@ enum FileMetadataReader {
     }
 
     private static func readSyncSafeInt(_ data: Data, at offset: Int) -> Int {
-        guard offset + 4 <= data.count else { return 0 }
+        guard offset >= 0, offset <= data.count - 4 else { return 0 }
         return (Int(data[offset] & 0x7F) << 21)
             | (Int(data[offset + 1] & 0x7F) << 14)
             | (Int(data[offset + 2] & 0x7F) << 7)
@@ -624,7 +624,9 @@ enum FileMetadataReader {
     }
 
     private static func asciiString(_ data: Data, start: Int, length: Int) -> String? {
-        guard start >= 0, length >= 0, start + length <= data.count else { return nil }
+        guard start >= 0, length >= 0, start <= data.count, length <= data.count - start else {
+            return nil
+        }
         return String(data: data.subdata(in: start..<(start + length)), encoding: .isoLatin1)
     }
 

--- a/Primuse/Services/Metadata/LyricsParser.swift
+++ b/Primuse/Services/Metadata/LyricsParser.swift
@@ -33,7 +33,8 @@ enum LyricsParser {
             }
 
             // 取最后一个行首时间戳之后的内容作为正文
-            let bodyStart = heads.last!.range.upperBound
+            guard let lastHead = heads.last else { continue }
+            let bodyStart = lastHead.range.upperBound
             let body = String(raw[bodyStart...])
 
             for head in heads {
@@ -83,8 +84,9 @@ enum LyricsParser {
         for i in 0..<(syllables.count - 1) {
             syllables[i].end = max(syllables[i].end, syllables[i + 1].start)
         }
-        if syllables.last!.end <= syllables.last!.start {
-            syllables[syllables.count - 1].end = syllables.last!.start + 0.4
+        if let lastIndex = syllables.indices.last,
+           syllables[lastIndex].end <= syllables[lastIndex].start {
+            syllables[lastIndex].end = syllables[lastIndex].start + 0.4
         }
 
         let plain = syllables.map(\.text).joined()
@@ -128,8 +130,9 @@ enum LyricsParser {
                 syllables[i].end = syllables[i + 1].start
             }
         }
-        if syllables.last!.end <= syllables.last!.start {
-            syllables[syllables.count - 1].end = syllables.last!.start + 0.4
+        if let lastIndex = syllables.indices.last,
+           syllables[lastIndex].end <= syllables[lastIndex].start {
+            syllables[lastIndex].end = syllables[lastIndex].start + 0.4
         }
 
         let plain = syllables.map(\.text).joined()

--- a/Primuse/Services/Metadata/MetadataAssetStore.swift
+++ b/Primuse/Services/Metadata/MetadataAssetStore.swift
@@ -29,9 +29,9 @@ actor MetadataAssetStore {
     private init(fileManager: FileManager = .default) {
         // tvOS 只允许写 Caches / tmp;Application Support 不可写(歌词/封面落不了盘)。
         #if os(tvOS)
-        let appSupport = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let appSupport = fileManager.primuseDirectoryURL(for: .cachesDirectory)
         #else
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = fileManager.primuseDirectoryURL(for: .applicationSupportDirectory)
         #endif
         let rootDirectory = appSupport.appendingPathComponent("Primuse/MetadataAssets", isDirectory: true)
         artworkDirectory = rootDirectory.appendingPathComponent("artwork", isDirectory: true)
@@ -52,7 +52,7 @@ actor MetadataAssetStore {
         try? fileManager.createDirectory(at: artworkContentDirectory, withIntermediateDirectories: true)
 
         // One-time migration from old Caches location
-        let oldRoot = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let oldRoot = fileManager.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent("primuse_metadata", isDirectory: true)
         migrateIfNeeded(from: oldRoot, fileManager: fileManager)
 

--- a/Primuse/Services/Metadata/MusicScraperService.swift
+++ b/Primuse/Services/Metadata/MusicScraperService.swift
@@ -41,7 +41,7 @@ final class MusicScraperService {
 
     init(sourceManager: SourceManager) {
         self.sourceManager = sourceManager
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = FileManager.default.primuseDirectoryURL(for: .applicationSupportDirectory)
         let directory = appSupport.appendingPathComponent("Primuse", isDirectory: true)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         scrapeCheckpointURL = directory.appendingPathComponent("scrape-checkpoint.json")
@@ -196,7 +196,7 @@ final class MusicScraperService {
                                 plog("⚠️ Sidecar write errors: \(writeResult.errors)")
                             }
                         } catch is CancellationError {
-                            plog("⚠️ Sidecar write timed out (\(Int(sidecarSettings.timeout))s) for '\(songForWrite.title)'")
+                            plog("⚠️ Sidecar write timed out (\(sidecarSettings.timeout.finiteInt())s) for '\(songForWrite.title)'")
                         } catch {
                             plog("⚠️ Sidecar write skipped for '\(songForWrite.title)': \(error.localizedDescription)")
                         }
@@ -313,7 +313,10 @@ final class MusicScraperService {
 
     func resumePendingScrape(in library: MusicLibrary) {
         guard !isScraping, let checkpoint = scrapeCheckpoint else { return }
-        let songsByID = Dictionary(uniqueKeysWithValues: library.visibleSongs.map { ($0.id, $0) })
+        let songsByID = Dictionary(
+            library.visibleSongs.map { ($0.id, $0) },
+            uniquingKeysWith: { current, _ in current }
+        )
         let startIndex = min(max(checkpoint.nextSongIndex, 0), checkpoint.songIDs.count)
         let songs = checkpoint.songIDs.dropFirst(startIndex).compactMap { songsByID[$0] }
         guard !songs.isEmpty else {
@@ -507,7 +510,7 @@ final class MusicScraperService {
                                         plog("⚠️ Batch sidecar errors for '\(songForWrite.title)': \(writeResult.errors)")
                                     }
                                 } catch is CancellationError {
-                                    plog("⚠️ Batch sidecar timed out (\(Int(sidecarSettings.timeout))s) for '\(songForWrite.title)'")
+                                    plog("⚠️ Batch sidecar timed out (\(sidecarSettings.timeout.finiteInt())s) for '\(songForWrite.title)'")
                                 } catch {
                                     plog("⚠️ Batch sidecar skipped for '\(songForWrite.title)': \(error.localizedDescription)")
                                 }
@@ -1054,7 +1057,9 @@ final class MusicScraperService {
                 return writeResult
             }
             group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(max(0.1, seconds) * 1_000_000_000))
+                let nanoseconds = (max(0.1, seconds) * 1_000_000_000)
+                    .finiteUInt64(or: 100_000_000)
+                try await Task.sleep(nanoseconds: nanoseconds)
                 throw CancellationError()
             }
 

--- a/Primuse/Services/Metadata/ScraperManager.swift
+++ b/Primuse/Services/Metadata/ScraperManager.swift
@@ -237,7 +237,7 @@ actor ScraperManager {
         durationMs targetMs: Int?,
         maxCount: Int
     ) -> [ScraperSearchItem] {
-        guard !items.isEmpty else { return [] }
+        guard !items.isEmpty, maxCount > 0 else { return [] }
         let normTitle = normalizeComparableText(title)
         let normArtist = normalizeComparableText(artist)
 

--- a/Primuse/Services/Metadata/Scrapers/ConfigurableScraper.swift
+++ b/Primuse/Services/Metadata/Scrapers/ConfigurableScraper.swift
@@ -478,7 +478,7 @@ actor ConfigurableScraper: MusicScraper {
             // 用公开 API 安全中断 JSContext; 这是不引私有符号下的合理代价)。
             watchdog.asyncAfter(deadline: .now() + timeout) {
                 if guardBox.claim() {
-                    plog("⏱️ JS[\(configID)] execution timed out after \(Int(timeout))s, abandoning")
+                    plog("⏱️ JS[\(configID)] execution timed out after \(timeout.finiteInt())s, abandoning")
                     continuation.resume(throwing: ScraperError.parseError("Script execution timed out"))
                 }
             }
@@ -798,7 +798,8 @@ enum PlainHTTPClient {
         guard let url = request.url,
               url.scheme == "http",
               let host = url.host,
-              let port = NWEndpoint.Port(rawValue: UInt16(url.port ?? 80)) else {
+              let rawPort = UInt16(exactly: url.port ?? 80),
+              let port = NWEndpoint.Port(rawValue: rawPort) else {
             throw ScraperError.networkError("Invalid HTTP URL: \(request.url?.absoluteString ?? "nil")")
         }
 
@@ -822,7 +823,7 @@ enum PlainHTTPClient {
             // receiveLoop 永不回调,这里兜底 cancel 连接并 finish,避免 continuation
             // 永久挂起及 NWConnection 泄漏。finish 幂等,正常完成后此回调是 no-op。
             queue.asyncAfter(deadline: .now() + timeout) {
-                finish(.failure(ScraperError.networkError("HTTP request timed out after \(Int(timeout))s")))
+                finish(.failure(ScraperError.networkError("HTTP request timed out after \(timeout.finiteInt())s")))
             }
 
             @Sendable func receiveLoop() {

--- a/Primuse/Services/Metadata/Scrapers/LRCLIBScraper.swift
+++ b/Primuse/Services/Metadata/Scrapers/LRCLIBScraper.swift
@@ -54,7 +54,7 @@ actor LRCLIBScraper: MusicScraper {
         }
         let safeDuration = duration?.sanitizedDuration ?? 0
         if safeDuration > 0 {
-            queryItems.append(URLQueryItem(name: "duration", value: String(Int(safeDuration.rounded(.down)))))
+            queryItems.append(URLQueryItem(name: "duration", value: String(safeDuration.rounded(.down).finiteInt())))
         }
         components.queryItems = queryItems
 

--- a/Primuse/Services/Metadata/Scrapers/ScraperConfigStore.swift
+++ b/Primuse/Services/Metadata/Scrapers/ScraperConfigStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PrimuseKit
 
 /// Non-persistent review payload shown before a custom scraper is imported.
 struct ScraperImportSummary: Sendable {
@@ -41,7 +42,7 @@ final class ScraperConfigStore: @unchecked Sendable {
     private let lock = NSLock()
 
     private init() {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = FileManager.default.primuseDirectoryURL(for: .applicationSupportDirectory)
         configDir = appSupport.appendingPathComponent("Primuse/ScraperConfigs")
         try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
         loadAll()
@@ -204,13 +205,14 @@ final class ScraperConfigStore: @unchecked Sendable {
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             throw ScraperConfigError.downloadFailed("HTTP \((response as? HTTPURLResponse)?.statusCode ?? 0)")
         }
-        if let length = http.value(forHTTPHeaderField: "Content-Length").flatMap(Int.init),
-           length > Self.maxRemoteImportBytes {
-            throw ScraperConfigError.downloadFailed("Response too large")
+        let declaredLength = http.value(forHTTPHeaderField: "Content-Length").flatMap(Int.init)
+        if let declaredLength,
+           declaredLength < 0 || declaredLength > Self.maxRemoteImportBytes {
+            throw ScraperConfigError.downloadFailed("Invalid response size")
         }
 
         var data = Data()
-        data.reserveCapacity(min(http.value(forHTTPHeaderField: "Content-Length").flatMap(Int.init) ?? 0, Self.maxRemoteImportBytes))
+        data.reserveCapacity(min(declaredLength ?? 0, Self.maxRemoteImportBytes))
         for try await byte in bytes {
             if data.count >= Self.maxRemoteImportBytes {
                 throw ScraperConfigError.downloadFailed("Response too large")

--- a/Primuse/Services/Metadata/Scrapers/XorZlibLyricsDecoder.swift
+++ b/Primuse/Services/Metadata/Scrapers/XorZlibLyricsDecoder.swift
@@ -46,7 +46,8 @@ enum XorZlibLyricsDecoder {
                 .replacingOccurrences(of: "]", with: "")
                 .split(separator: ",")
             guard nums.count == 2,
-                  let lineStart = Int(nums[0]), let lineDur = Int(nums[1]) else { continue }
+                  let lineStart = Int(nums[0]), let lineDur = Int(nums[1]),
+                  let lineEnd = safeAdd(lineStart, lineDur) else { continue }
 
             let body = String(line[head.upperBound...])
             let pieces = parseWordPieces(body)
@@ -57,11 +58,13 @@ enum XorZlibLyricsDecoder {
 
             lineOut.append("[\(fmt(lineStart))]\(plain)")
 
+            let absoluteStarts = pieces.compactMap { safeAdd(lineStart, $0.offsetRel) }
+            guard absoluteStarts.count == pieces.count else { continue }
             var wordLine = "[\(fmt(lineStart))]"
-            for p in pieces {
-                wordLine += "<\(fmt(lineStart + p.offsetRel))>\(p.text)"
+            for (piece, absoluteStart) in zip(pieces, absoluteStarts) {
+                wordLine += "<\(fmt(absoluteStart))>\(piece.text)"
             }
-            wordLine += "<\(fmt(lineStart + lineDur))>"
+            wordLine += "<\(fmt(lineEnd))>"
             wordOut.append(wordLine)
         }
 
@@ -91,12 +94,18 @@ enum XorZlibLyricsDecoder {
     }
 
     private static func fmt(_ ms: Int) -> String {
-        let totalCs = (ms + 5) / 10
+        // Round without `ms + 5`, which can overflow on malformed lyrics.
+        let totalCs = ms / 10 + (ms % 10 >= 5 ? 1 : 0)
         let cs = totalCs % 100
         let totalSec = totalCs / 100
         let s = totalSec % 60
         let m = totalSec / 60
         return String(format: "%02d:%02d.%02d", m, s, cs)
+    }
+
+    private static func safeAdd(_ lhs: Int, _ rhs: Int) -> Int? {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? nil : sum
     }
 
     private static func inflateZlib(_ data: Data) -> Data? {

--- a/Primuse/Services/Playlist/PlaylistExporter.swift
+++ b/Primuse/Services/Playlist/PlaylistExporter.swift
@@ -88,7 +88,7 @@ enum PlaylistExporter {
         lines.append("#PLAYLIST:\(playlist.name)")
         for song in songs {
             // EXTINF: 时长 (秒, 整数), 艺术家 - 歌曲名
-            let duration = max(0, Int(song.duration.rounded()))
+            let duration = max(0, song.duration.rounded().finiteInt())
             let displayArtist = song.artistName ?? ""
             let title = displayArtist.isEmpty ? song.title : "\(displayArtist) - \(song.title)"
             lines.append("#EXTINF:\(duration),\(title)")
@@ -138,7 +138,9 @@ enum PlaylistExporter {
                 title: song.title,
                 artistName: song.artistName,
                 albumTitle: song.albumTitle,
-                durationSec: song.duration > 0 ? Int(song.duration) : nil,
+                durationSec: song.duration.isFinite && song.duration > 0
+                    ? song.duration.finiteInt()
+                    : nil,
                 trackNumber: song.trackNumber,
                 discNumber: song.discNumber,
                 fileFormat: song.fileFormat.displayName,

--- a/Primuse/Services/Playlist/PlaylistImporter.swift
+++ b/Primuse/Services/Playlist/PlaylistImporter.swift
@@ -93,7 +93,10 @@ enum PlaylistImporter {
         // 命中停用源的歌只会出现在全量 library.songs 里, 写进歌单后通过
         // songs(forPlaylist:) 也看不到, 会造成"导入成功却凭空少歌"。
         let visibleSongs = library.visibleSongs
-        let songsByID = Dictionary(uniqueKeysWithValues: visibleSongs.map { ($0.id, $0) })
+        let songsByID = Dictionary(
+            visibleSongs.map { ($0.id, $0) },
+            uniquingKeysWith: { current, _ in current }
+        )
         let entries = file.tracks.map { track -> ImportEntry in
             // 1. song.id 完全匹配
             if let s = songsByID[track.songID] {

--- a/Primuse/Services/Scrobble/ScrobbleService.swift
+++ b/Primuse/Services/Scrobble/ScrobbleService.swift
@@ -117,7 +117,7 @@ final class ScrobbleService {
               var session = currentSession,
               session.entry.songID == songID else { return }
 
-        let durationSec = Int(duration)
+        let durationSec = duration.finiteInt()
         guard durationSec > 0, session.entry.durationSec != durationSec else { return }
 
         let old = session.entry
@@ -297,7 +297,8 @@ final class ScrobbleService {
                 // 等到下一个 due 时间, 最长睡 60s 一次让 cancel 能生效
                 let nextWake = (queue.map(\.nextRetryAt).min() ?? now) - now
                 let sleep = max(5, min(60, nextWake))
-                try? await Task.sleep(nanoseconds: UInt64(sleep * 1_000_000_000))
+                let nanoseconds = (sleep * 1_000_000_000).finiteUInt64(or: 5_000_000_000)
+                try? await Task.sleep(nanoseconds: nanoseconds)
                 if Task.isCancelled { return }
                 continue
             }
@@ -409,7 +410,9 @@ final class ScrobbleService {
             artist: song.artistName ?? "Unknown Artist",
             album: song.albumTitle,
             albumArtist: nil,
-            durationSec: song.duration > 0 ? Int(song.duration) : nil,
+            durationSec: song.duration.isFinite && song.duration > 0
+                ? song.duration.finiteInt()
+                : nil,
             trackNumber: song.trackNumber,
             startedAt: Int64(Date().timeIntervalSince1970)
         )

--- a/Primuse/Services/Sources/CloudDrive/BaiduPanSource.swift
+++ b/Primuse/Services/Sources/CloudDrive/BaiduPanSource.swift
@@ -700,7 +700,8 @@ actor BaiduPanSource: MusicSourceConnector, OAuthCloudSource {
             // 31034: 接口频次超限 — 退避重试
             if errno == 31034, attempt < Self.rateLimitMaxRetries {
                 plog("☁️ Baidu rate-limited, backoff \(backoff)s and retry")
-                try await Task.sleep(nanoseconds: UInt64(backoff * 1_000_000_000))
+                let nanoseconds = (backoff * 1_000_000_000).finiteUInt64(or: 1_000_000_000)
+                try await Task.sleep(nanoseconds: nanoseconds)
                 backoff *= 2
                 attempt += 1
                 continue
@@ -718,7 +719,8 @@ actor BaiduPanSource: MusicSourceConnector, OAuthCloudSource {
         lastRequestAt = reservedTime
         let wait = reservedTime.timeIntervalSince(now)
         if wait > 0 {
-            try await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
+            let nanoseconds = (wait * 1_000_000_000).finiteUInt64()
+            try await Task.sleep(nanoseconds: nanoseconds)
         }
     }
 

--- a/Primuse/Services/Sources/CloudDrive/CloudDriveBase.swift
+++ b/Primuse/Services/Sources/CloudDrive/CloudDriveBase.swift
@@ -78,7 +78,7 @@ struct CloudDriveHelper: Sendable {
     let tokenManager: CloudTokenManager
 
     var cacheDirectory: URL {
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let cacheDir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent("primuse_cloud_cache/\(sourceID)")
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
         return cacheDir
@@ -152,14 +152,11 @@ struct CloudDriveHelper: Sendable {
                 throw CloudDriveError.apiError(code, "Range request failed (TCP)")
             }
         }
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        let rangeHeader: String
-        if offset < 0 {
-            rangeHeader = "bytes=\(offset)"  // suffix-byte-range form: bytes=-N
-        } else {
-            rangeHeader = "bytes=\(offset)-\(offset + length - 1)"
-        }
         request.setValue(rangeHeader, forHTTPHeaderField: "Range")
         if let accessToken {
             request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
@@ -188,7 +185,10 @@ struct CloudDriveHelper: Sendable {
                 ? max(0, totalSize + offset)
                 : offset
             guard actualOffset < totalSize else { return Data() }
-            let upper = min(actualOffset + length, totalSize)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: actualOffset, length: length) else {
+                return Data()
+            }
+            let upper = min(requestedEnd, totalSize)
             return data.subdata(in: Int(actualOffset)..<Int(upper))
         default:
             // Surface the status code so the caller can decide whether

--- a/Primuse/Services/Sources/CloudDrive/TCPRangeFetcher.swift
+++ b/Primuse/Services/Sources/CloudDrive/TCPRangeFetcher.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import PrimuseKit
 import Security
 
 /// 用 `NWConnection` 走 TCP + HTTP/1.1 发 Range GET，从协议层绕开 HTTP/3(QUIC)。
@@ -55,7 +56,8 @@ enum TCPRangeFetcher {
         timeoutSeconds: TimeInterval
     ) async throws -> Data {
         guard let host = url.host else { throw FetchError.badURL }
-        let port = NWEndpoint.Port(rawValue: UInt16(url.port ?? 443)) ?? 443
+        let rawPort = UInt16(exactly: url.port ?? 443) ?? 443
+        let port = NWEndpoint.Port(rawValue: rawPort) ?? 443
         let endpoint = await TCPConnectionPool.shared.endpoint(host: host, port: port)
         return try await endpoint.fetch(
             url: url, offset: offset, length: length,
@@ -197,7 +199,9 @@ private actor TCPHostEndpoint {
                     )
                 }
                 group.addTask {
-                    try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                    let nanoseconds = (max(0.1, timeoutSeconds) * 1_000_000_000)
+                        .finiteUInt64(or: 100_000_000)
+                    try await Task.sleep(nanoseconds: nanoseconds)
                     pooled.cancel()  // 取消连接，唤醒上面挂起的握手/收发 continuation。
                     throw TCPRangeFetcher.FetchError.timeout
                 }
@@ -306,7 +310,9 @@ private final class PooledConnection: @unchecked Sendable {
         let encodedPath = comps?.percentEncodedPath ?? url.path
         var path = encodedPath.isEmpty ? "/" : encodedPath
         if let q = comps?.percentEncodedQuery ?? url.query, !q.isEmpty { path += "?" + q }
-        let rangeHeader = offset < 0 ? "bytes=\(offset)" : "bytes=\(offset)-\(offset + length - 1)"
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            throw TCPRangeFetcher.FetchError.malformedResponse
+        }
         var head = "GET \(path) HTTP/1.1\r\n"
         head += "Host: \(host)\r\n"
         head += "Range: \(rangeHeader)\r\n"
@@ -332,7 +338,10 @@ private final class PooledConnection: @unchecked Sendable {
             let total = Int64(body.count)
             let actualOffset = offset < 0 ? max(0, total + offset) : offset
             guard actualOffset < total else { return Data() }
-            let upper = min(actualOffset + length, total)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: actualOffset, length: length) else {
+                return Data()
+            }
+            let upper = min(requestedEnd, total)
             return body.subdata(in: Int(actualOffset)..<Int(upper))
         default:
             throw TCPRangeFetcher.FetchError.http(status)
@@ -443,7 +452,10 @@ private final class PooledConnection: @unchecked Sendable {
             if lower.hasPrefix("content-length:") {
                 let v = line.drop(while: { $0 != ":" }).dropFirst()
                     .trimmingCharacters(in: .whitespaces)
-                cl = Int(v)
+                guard let parsedLength = Int(v), parsedLength >= 0 else {
+                    throw TCPRangeFetcher.FetchError.malformedResponse
+                }
+                cl = parsedLength
             } else if lower.hasPrefix("transfer-encoding:") && lower.contains("chunked") {
                 chunked = true
             }
@@ -461,7 +473,8 @@ private final class PooledConnection: @unchecked Sendable {
             let sizeLine = data.subdata(in: i..<lineEnd.lowerBound)
             guard let sizeStr = String(data: sizeLine, encoding: .ascii)?
                 .split(separator: ";").first.map(String.init),
-                  let size = Int(sizeStr.trimmingCharacters(in: .whitespaces), radix: 16) else { return nil }
+                  let size = Int(sizeStr.trimmingCharacters(in: .whitespaces), radix: 16),
+                  size >= 0 else { return nil }
             if size == 0 {
                 // 终止块：到最终空行(可能带 trailer)为止。
                 if let term = data.range(of: dblCrlf, in: i..<data.endIndex) {
@@ -490,7 +503,8 @@ private final class PooledConnection: @unchecked Sendable {
             let sizeLine = data.subdata(in: i..<lineEnd.lowerBound)
             guard let sizeStr = String(data: sizeLine, encoding: .ascii)?
                 .split(separator: ";").first.map(String.init),
-                  let size = Int(sizeStr.trimmingCharacters(in: .whitespaces), radix: 16) else { break }
+                  let size = Int(sizeStr.trimmingCharacters(in: .whitespaces), radix: 16),
+                  size >= 0 else { break }
             if size == 0 { break }
             let chunkStart = lineEnd.upperBound
             let chunkEnd = data.index(chunkStart, offsetBy: size, limitedBy: data.endIndex) ?? data.endIndex

--- a/Primuse/Services/Sources/FnOSSource.swift
+++ b/Primuse/Services/Sources/FnOSSource.swift
@@ -29,7 +29,7 @@ actor FnOSSource: MusicSourceConnector {
         self.sourceID = sourceID
         self.api = FnOSAPI(host: host, port: port, useSsl: useSsl)
         self.username = username; self.password = password
-        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let dir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent("primuse_audio_cache/\(sourceID)")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.cacheDirectory = dir
@@ -111,14 +111,14 @@ actor FnOSSource: MusicSourceConnector {
     /// 直接生效, 让 CloudPlaybackSource 边下边播替代整文件下载。
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
         try await connect()
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
         guard let url = await api.downloadURL(path: path) else {
             throw SourceError.fileNotFound(path)
         }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        let rangeHeader = offset < 0
-            ? "bytes=\(offset)"  // suffix-byte form: bytes=-N
-            : "bytes=\(offset)-\(offset + length - 1)"
         request.setValue(rangeHeader, forHTTPHeaderField: "Range")
         if let token = await api.token {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -145,7 +145,10 @@ actor FnOSSource: MusicSourceConnector {
             let total = Int64(data.count)
             let actualOffset = offset < 0 ? max(0, total + offset) : offset
             guard actualOffset < total else { return Data() }
-            let upper = min(actualOffset + length, total)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: actualOffset, length: length) else {
+                return Data()
+            }
+            let upper = min(requestedEnd, total)
             return data.subdata(in: Int(actualOffset)..<Int(upper))
         default:
             throw SourceError.connectionFailed("fnOS range request failed: HTTP \(http.statusCode)")

--- a/Primuse/Services/Sources/MediaServerSource.swift
+++ b/Primuse/Services/Sources/MediaServerSource.swift
@@ -733,7 +733,7 @@ actor MediaServerSource: RefreshingMetadataSongConnector, MediaServerWritebackCo
 
     private static func lyricsToLRC(_ lines: [LyricLine]) -> String {
         lines.map { line in
-            let minutes = Int(line.timestamp) / 60
+            let minutes = line.timestamp.finiteInt() / 60
             let seconds = line.timestamp - Double(minutes * 60)
             return String(format: "[%02d:%05.2f]%@", minutes, seconds, line.text)
         }

--- a/Primuse/Services/Sources/MusicSourceProtocol.swift
+++ b/Primuse/Services/Sources/MusicSourceProtocol.swift
@@ -280,6 +280,7 @@ extension MusicSourceConnector {
     /// Default fallback: download the whole file via `localURL` then slice.
     /// Correct but slow. Cloud connectors override this with HTTP Range.
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
+        guard length > 0 else { return Data() }
         let url = try await localURL(for: path)
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
@@ -288,6 +289,9 @@ extension MusicSourceConnector {
         if offset < 0 {
             actualOffset = UInt64(max(0, fileSize + offset))
         } else {
+            guard SafeByteRange.exclusiveEnd(offset: offset, length: length) != nil else {
+                return Data()
+            }
             actualOffset = UInt64(offset)
         }
         try handle.seek(toOffset: actualOffset)

--- a/Primuse/Services/Sources/NFSSource.swift
+++ b/Primuse/Services/Sources/NFSSource.swift
@@ -231,6 +231,7 @@ actor NFSSource: MusicSourceConnector {
     /// 的 NFS_READ RPC (offset + count), 协议级支持任意 offset 读, 让
     /// CloudPlaybackSource 边下边播替代整文件下载。
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
+        guard length > 0 else { return Data() }
         let selection = try resolveSelectionPath(for: path)
         let client = try resolveClient()
         try await ensureConnected(to: selection.exportPath)
@@ -258,11 +259,17 @@ actor NFSSource: MusicSourceConnector {
                 }
             }
             let start = max(0, total + offset)
-            let end = min(total, start + length)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: start, length: length) else {
+                return Data()
+            }
+            let end = min(total, requestedEnd)
             guard start < end else { return Data() }
             actualRange = start..<end
         } else {
-            actualRange = offset..<(offset + length)
+            guard let end = SafeByteRange.exclusiveEnd(offset: offset, length: length) else {
+                return Data()
+            }
+            actualRange = offset..<end
         }
 
         return try await withCheckedThrowingContinuation { continuation in

--- a/Primuse/Services/Sources/QnapSource.swift
+++ b/Primuse/Services/Sources/QnapSource.swift
@@ -28,7 +28,7 @@ actor QnapSource: MusicSourceConnector {
         self.sourceID = sourceID
         self.api = QnapAPI(host: host, port: port, useSsl: useSsl)
         self.username = username; self.password = password
-        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let dir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent("primuse_audio_cache/\(sourceID)")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.cacheDirectory = dir
@@ -132,9 +132,9 @@ actor QnapSource: MusicSourceConnector {
         }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        let rangeHeader = offset < 0
-            ? "bytes=\(offset)"
-            : "bytes=\(offset)-\(offset + length - 1)"
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
         request.setValue(rangeHeader, forHTTPHeaderField: "Range")
         request.timeoutInterval = 60
 
@@ -157,7 +157,10 @@ actor QnapSource: MusicSourceConnector {
             let total = Int64(data.count)
             let actualOffset = offset < 0 ? max(0, total + offset) : offset
             guard actualOffset < total else { return Data() }
-            let upper = min(actualOffset + length, total)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: actualOffset, length: length) else {
+                return Data()
+            }
+            let upper = min(requestedEnd, total)
             return data.subdata(in: Int(actualOffset)..<Int(upper))
         default:
             throw SourceError.connectionFailed("QNAP range request failed: HTTP \(http.statusCode)")

--- a/Primuse/Services/Sources/S3Source.swift
+++ b/Primuse/Services/Sources/S3Source.swift
@@ -43,7 +43,7 @@ actor S3Source: MusicSourceConnector {
         self.secretKey = secretKey
         self.useSsl = useSsl
 
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let cacheDir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent("primuse_s3_cache/\(sourceID)")
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
         self.cacheDirectory = cacheDir
@@ -129,9 +129,9 @@ actor S3Source: MusicSourceConnector {
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
         let url = try objectURL(for: path)
         var request = try signedRequest(url: url, method: "GET")
-        let rangeHeader = offset < 0
-            ? "bytes=\(offset)"
-            : "bytes=\(offset)-\(offset + length - 1)"
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
         request.setValue(rangeHeader, forHTTPHeaderField: "Range")
         request.timeoutInterval = 60
 
@@ -146,7 +146,10 @@ actor S3Source: MusicSourceConnector {
             let total = Int64(data.count)
             let actualOffset = offset < 0 ? max(0, total + offset) : offset
             guard actualOffset < total else { return Data() }
-            let upper = min(actualOffset + length, total)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: actualOffset, length: length) else {
+                return Data()
+            }
+            let upper = min(requestedEnd, total)
             return data.subdata(in: Int(actualOffset)..<Int(upper))
         default:
             throw SourceError.connectionFailed("S3 range request failed: HTTP \(http.statusCode)")

--- a/Primuse/Services/Sources/SFTPSource.swift
+++ b/Primuse/Services/Sources/SFTPSource.swift
@@ -190,6 +190,7 @@ actor SFTPSource: MusicSourceConnector {
     /// 每次开关 file handle 一次 (SSH 连接复用), 8 路并发 prefetch 时
      /// 同时开多个 file 也安全。
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
+        guard length > 0 else { return Data() }
         guard let sftp else {
             throw SourceError.connectionFailed("Not connected")
         }

--- a/Primuse/Services/Sources/SMBSource.swift
+++ b/Primuse/Services/Sources/SMBSource.swift
@@ -138,6 +138,7 @@ actor SMBSource: MusicSourceConnector {
      /// 的 SMB2 READ (8-byte offset), 协议级支持 byte range, 让 CloudPlaybackSource
      /// 边下边播替代整文件下载。
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
+        guard length > 0 else { return Data() }
         let normalizedPath = Self.normalizeRemotePath(path)
         let resolvedPath = try resolve(path: normalizedPath)
         guard case let .share(shareName, relativePath) = resolvedPath else {
@@ -157,13 +158,19 @@ actor SMBSource: MusicSourceConnector {
                     throw SourceError.fileNotFound(relativePath)
                 }
                 let start = max(0, total + offset)
-                let end = min(total, start + length)
+                guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: start, length: length) else {
+                    return Data()
+                }
+                let end = min(total, requestedEnd)
                 guard start < end else { return Data() }
                 return try await client.contents(atPath: relativePath, range: UInt64(start)..<UInt64(end))
             }
+            guard let end = SafeByteRange.exclusiveEnd(offset: offset, length: length) else {
+                return Data()
+            }
             return try await client.contents(
                 atPath: relativePath,
-                range: UInt64(offset)..<UInt64(offset + length)
+                range: UInt64(offset)..<UInt64(end)
             )
         }
     }

--- a/Primuse/Services/Sources/SourceManager.swift
+++ b/Primuse/Services/Sources/SourceManager.swift
@@ -924,7 +924,8 @@ final class SourceManager {
                 try await operation()
             }
             group.addTask {
-                let nanoseconds = UInt64(max(0.1, seconds) * 1_000_000_000)
+                let nanoseconds = (max(0.1, seconds) * 1_000_000_000)
+                    .finiteUInt64(or: 100_000_000)
                 try await Task.sleep(nanoseconds: nanoseconds)
                 throw SourceError.timeout
             }
@@ -1072,7 +1073,7 @@ final class SourceManager {
     private nonisolated static let videoCacheChunkBytes: Int64 = 4 * 1024 * 1024
 
     private func videoCacheDirectory(for sourceID: String) -> URL {
-        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let dir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent(Self.videoCacheDirName)
             .appendingPathComponent(sourceID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -1308,7 +1309,7 @@ final class SourceManager {
     }
 
     private nonisolated func evictVideoCache(reserveBytes: Int64, protectedPaths: Set<String>) {
-        let basePath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let basePath = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent(Self.videoCacheDirName)
         guard let enumerator = FileManager.default.enumerator(
             at: basePath,
@@ -1362,7 +1363,7 @@ final class SourceManager {
     private static let directDownloadUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
 
     private func audioCacheDirectory(for sourceID: String) -> URL {
-        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let dir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent(Self.audioCacheDirName)
             .appendingPathComponent(sourceID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -1875,7 +1876,7 @@ final class SourceManager {
     /// 在任意线程跑。
     private static var audioCacheSizeDirs: [URL] {
         [
-            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+            FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
                 .appendingPathComponent(audioCacheDirName),
             smbCacheDir,
         ]
@@ -1886,7 +1887,7 @@ final class SourceManager {
     /// (否则统计会系统性低估 SMB/SFTP/NFS/云 等源的真实占用)。
     static func perSourceCacheDirs(sourceID: String) -> [URL] {
         let fm = FileManager.default
-        let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let caches = fm.primuseDirectoryURL(for: .cachesDirectory)
         let temp = fm.temporaryDirectory
         return [
             caches.appendingPathComponent(audioCacheDirName).appendingPathComponent(sourceID),
@@ -1954,7 +1955,7 @@ final class SourceManager {
     }
 
     func audioCacheBreakdown() async -> AudioCacheBreakdown {
-        let basePath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let basePath = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent(Self.audioCacheDirName)
         let aliveSourceIDs: Set<String>
         if let sources = try? await sourcesProvider() {
@@ -2065,7 +2066,7 @@ final class SourceManager {
     /// 重新下, 但不会丢功能。
     @discardableResult
     func purgeAllPartialFiles() -> (freedBytes: Int64, failedCount: Int) {
-        let basePath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let basePath = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent(Self.audioCacheDirName)
         var freed: Int64 = 0
         var failed = 0
@@ -2107,7 +2108,7 @@ final class SourceManager {
     func deleteLocalCaches(for songs: [Song]) {
         guard songs.isEmpty == false else { return }
 
-        let cachesRoot = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let cachesRoot = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
         let tempRoot = FileManager.default.temporaryDirectory
         var cacheTargets: [URL] = []
         cacheTargets.reserveCapacity(songs.count * 6)
@@ -2277,7 +2278,7 @@ final class SourceManager {
     /// removeItem 是 best-effort 的最后一步。
     @discardableResult
     func clearAudioCache() async -> (freedBytes: Int64, failedCount: Int) {
-        let basePath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let basePath = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent(Self.audioCacheDirName)
         var freed: Int64 = 0
         var failed = 0
@@ -2333,7 +2334,7 @@ final class SourceManager {
     /// 只清 mtime 超过阈值的, 现在正在 streaming 的 `.partial` (mtime
     /// 是新的) 不会被误删。
     func pruneStalePartialFiles(olderThanDays days: Int = 7) {
-        let basePath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let basePath = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent(Self.audioCacheDirName)
         guard let enumerator = FileManager.default.enumerator(
             at: basePath,
@@ -2367,7 +2368,7 @@ final class SourceManager {
     /// 回收磁盘, 不然 caches/primuse_audio_cache/<sourceID>/ 里的整本歌
     /// + `.partial` 半成品永远没人动。
     func purgeAudioCache(forSourceID sourceID: String) {
-        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let dir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent(Self.audioCacheDirName)
             .appendingPathComponent(sourceID)
         try? FileManager.default.removeItem(at: dir)

--- a/Primuse/Services/Sources/SourcesStore.swift
+++ b/Primuse/Services/Sources/SourcesStore.swift
@@ -36,9 +36,9 @@ final class SourcesStore {
     init(fileManager: FileManager = .default) {
         // tvOS 只允许写 Caches / tmp;须与 LibrarySnapshotSync / MusicLibrary 同目录。
         #if os(tvOS)
-        let appSupport = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let appSupport = fileManager.primuseDirectoryURL(for: .cachesDirectory)
         #else
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = fileManager.primuseDirectoryURL(for: .applicationSupportDirectory)
         #endif
         let directory = appSupport.appendingPathComponent("Primuse", isDirectory: true)
         try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/Primuse/Services/Sources/SubsonicSource.swift
+++ b/Primuse/Services/Sources/SubsonicSource.swift
@@ -254,6 +254,9 @@ actor SubsonicSource: SongScanningConnector, ServerScrobblingConnector, ServerLy
     /// 元数据齐全, backfill 跳过它, 正常只会收到正 offset。
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
         try await connect()
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
         guard let songID = songID(from: path),
               let url = buildRESTURL(
                   method: "stream",
@@ -266,11 +269,7 @@ actor SubsonicSource: SongScanningConnector, ServerScrobblingConnector, ServerLy
         }
 
         var request = URLRequest(url: url)
-        if offset < 0 {
-            request.setValue("bytes=\(offset)", forHTTPHeaderField: "Range")
-        } else {
-            request.setValue("bytes=\(offset)-\(offset + length - 1)", forHTTPHeaderField: "Range")
-        }
+        request.setValue(rangeHeader, forHTTPHeaderField: "Range")
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
             throw SourceError.connectionFailed("HTTP \((response as? HTTPURLResponse)?.statusCode ?? 0)")

--- a/Primuse/Services/Sources/SynologyScanner.swift
+++ b/Primuse/Services/Sources/SynologyScanner.swift
@@ -462,7 +462,7 @@ actor SynologyScanner {
         // Try to download file header and parse with AVFoundation
         do {
             // Download first 4MB (enough for ID3/FLAC/MP4 metadata + cover art)
-            let readSize = min(Int(item.size), 4 * 1024 * 1024)
+            let readSize = min(Int(clamping: item.size), 4 * 1024 * 1024)
             guard readSize > 0 else {
                 return makeSong(id: songID, title: title, artist: artist, album: album,
                                trackNumber: trackNumber, duration: duration, format: format,

--- a/Primuse/Services/Sources/SynologySource.swift
+++ b/Primuse/Services/Sources/SynologySource.swift
@@ -44,7 +44,7 @@ actor SynologySource: MusicSourceConnector {
         self.deviceId = deviceId
 
         // Use Caches directory (survives app restarts, system can purge when low on storage)
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let cacheDir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent("primuse_audio_cache/\(sourceID)")
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
         self.cacheDirectory = cacheDir
@@ -213,14 +213,14 @@ actor SynologySource: MusicSourceConnector {
     }
 
     private func fetchRangeOnce(path: String, offset: Int64, length: Int64) async throws -> Data {
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
         guard let url = try await streamingURL(for: path) else {
             throw SynologyError.invalidURL
         }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        let rangeHeader = offset < 0
-            ? "bytes=\(offset)"  // suffix-byte form: bytes=-N (last N bytes)
-            : "bytes=\(offset)-\(offset + length - 1)"
         request.setValue(rangeHeader, forHTTPHeaderField: "Range")
         request.timeoutInterval = 60
 
@@ -252,7 +252,10 @@ actor SynologySource: MusicSourceConnector {
             let total = Int64(data.count)
             let actualOffset = offset < 0 ? max(0, total + offset) : offset
             guard actualOffset < total else { return Data() }
-            let upper = min(actualOffset + length, total)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: actualOffset, length: length) else {
+                return Data()
+            }
+            let upper = min(requestedEnd, total)
             return data.subdata(in: Int(actualOffset)..<Int(upper))
         case 401:
             // Session expired —— surface as notLoggedIn so fetchRange can

--- a/Primuse/Services/Sources/UPnPSource.swift
+++ b/Primuse/Services/Sources/UPnPSource.swift
@@ -115,17 +115,15 @@ actor UPnPSource: SongScanningConnector {
     }
 
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
-        guard length > 0 else { return Data() }
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
 
         let remoteURL = try playbackURL(for: path)
         var request = URLRequest(url: remoteURL)
         request.httpMethod = "GET"
         request.timeoutInterval = 30
-        if offset < 0 {
-            request.setValue("bytes=\(offset)", forHTTPHeaderField: "Range")
-        } else {
-            request.setValue("bytes=\(offset)-\(offset + length - 1)", forHTTPHeaderField: "Range")
-        }
+        request.setValue(rangeHeader, forHTTPHeaderField: "Range")
 
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -139,7 +137,10 @@ actor UPnPSource: SongScanningConnector {
             let totalSize = Int64(data.count)
             let actualOffset = offset < 0 ? max(0, totalSize + offset) : offset
             guard actualOffset < totalSize else { return Data() }
-            let upperBound = min(actualOffset + length, totalSize)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: actualOffset, length: length) else {
+                return Data()
+            }
+            let upperBound = min(requestedEnd, totalSize)
             return data.subdata(in: Int(actualOffset)..<Int(upperBound))
         default:
             throw SourceError.connectionFailed("UPnP range request failed: HTTP \(httpResponse.statusCode)")

--- a/Primuse/Services/Sources/UgreenSource.swift
+++ b/Primuse/Services/Sources/UgreenSource.swift
@@ -27,7 +27,7 @@ actor UgreenSource: MusicSourceConnector {
         self.sourceID = sourceID
         self.api = UgreenAPI(host: host, port: port, useSsl: useSsl)
         self.username = username; self.password = password
-        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let dir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
             .appendingPathComponent("primuse_audio_cache/\(sourceID)")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.cacheDirectory = dir
@@ -108,14 +108,14 @@ actor UgreenSource: MusicSourceConnector {
     /// 下载。
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
         try await connect()
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
         guard let url = await api.downloadURL(path: path) else {
             throw SourceError.fileNotFound(path)
         }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        let rangeHeader = offset < 0
-            ? "bytes=\(offset)"
-            : "bytes=\(offset)-\(offset + length - 1)"
         request.setValue(rangeHeader, forHTTPHeaderField: "Range")
         request.timeoutInterval = 60
 
@@ -138,7 +138,10 @@ actor UgreenSource: MusicSourceConnector {
             let total = Int64(data.count)
             let actualOffset = offset < 0 ? max(0, total + offset) : offset
             guard actualOffset < total else { return Data() }
-            let upper = min(actualOffset + length, total)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: actualOffset, length: length) else {
+                return Data()
+            }
+            let upper = min(requestedEnd, total)
             return data.subdata(in: Int(actualOffset)..<Int(upper))
         default:
             throw SourceError.connectionFailed("Ugreen range request failed: HTTP \(http.statusCode)")

--- a/Primuse/Services/Sources/WebDAVSource.swift
+++ b/Primuse/Services/Sources/WebDAVSource.swift
@@ -202,13 +202,12 @@ actor WebDAVSource: MusicSourceConnector {
     }
 
     func fetchRange(path: String, offset: Int64, length: Int64) async throws -> Data {
+        guard let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) else {
+            return Data()
+        }
         var request = URLRequest(url: try fileURL(for: path))
         request.httpMethod = "GET"
-        if offset < 0 {
-            request.setValue("bytes=\(offset)", forHTTPHeaderField: "Range")
-        } else {
-            request.setValue("bytes=\(offset)-\(offset + length - 1)", forHTTPHeaderField: "Range")
-        }
+        request.setValue(rangeHeader, forHTTPHeaderField: "Range")
         if !username.isEmpty || !password.isEmpty {
             let credential = Data("\(username):\(password)".utf8).base64EncodedString()
             request.setValue("Basic \(credential)", forHTTPHeaderField: "Authorization")
@@ -226,7 +225,10 @@ actor WebDAVSource: MusicSourceConnector {
             let totalSize = Int64(data.count)
             let actualOffset = offset < 0 ? max(0, totalSize + offset) : offset
             guard actualOffset < totalSize else { return Data() }
-            let upper = min(actualOffset + length, totalSize)
+            guard let requestedEnd = SafeByteRange.exclusiveEnd(offset: actualOffset, length: length) else {
+                return Data()
+            }
+            let upper = min(requestedEnd, totalSize)
             return data.subdata(in: Int(actualOffset)..<Int(upper))
         default:
             throw SourceError.connectionFailed("WebDAV range request failed: HTTP \(http.statusCode)")

--- a/Primuse/Services/Stats/PlayHistoryArchiver.swift
+++ b/Primuse/Services/Stats/PlayHistoryArchiver.swift
@@ -139,7 +139,7 @@ enum PlayHistoryArchiver {
     }
 
     private static func archiveDirectory() -> URL {
-        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        FileManager.default.primuseDirectoryURL(for: .applicationSupportDirectory)
             .appendingPathComponent("Primuse", isDirectory: true)
             .appendingPathComponent(directoryName, isDirectory: true)
     }

--- a/Primuse/Utilities/Extensions/TimeInterval+Format.swift
+++ b/Primuse/Utilities/Extensions/TimeInterval+Format.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PrimuseKit
 
 extension TimeInterval {
     static func sanitized(_ value: TimeInterval?) -> TimeInterval {
@@ -11,7 +12,7 @@ extension TimeInterval {
     }
 
     var formattedDuration: String {
-        let totalSeconds = Int(sanitizedDuration.rounded(.down))
+        let totalSeconds = sanitizedDuration.rounded(.down).finiteInt()
         let hours = totalSeconds / 3600
         let minutes = (totalSeconds % 3600) / 60
         let seconds = totalSeconds % 60
@@ -23,7 +24,7 @@ extension TimeInterval {
     }
 
     var formattedShort: String {
-        let totalSeconds = Int(sanitizedDuration.rounded(.down))
+        let totalSeconds = sanitizedDuration.rounded(.down).finiteInt()
         let hours = totalSeconds / 3600
         let minutes = (totalSeconds % 3600) / 60
 

--- a/Primuse/Utilities/FileLogger.swift
+++ b/Primuse/Utilities/FileLogger.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PrimuseKit
 
 /// Thread-safe file logger that writes to the app's Caches directory.
 /// The log file URL is exposed via `logFileURL` for sharing/diagnostics
@@ -24,7 +25,7 @@ final class FileLogger: @unchecked Sendable {
     private var currentBytes: Int = 0
 
     private init() {
-        let docs = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let docs = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
         fileURL = docs.appendingPathComponent("primuse_debug.log")
         rotatedURL = docs.appendingPathComponent("primuse_debug.log.1")
 

--- a/Primuse/Utilities/ImageCache.swift
+++ b/Primuse/Utilities/ImageCache.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PrimuseKit
 #if os(iOS)
 #if os(iOS)
 import UIKit
@@ -17,7 +18,7 @@ actor ImageCache {
         memoryCache.countLimit = 200
         memoryCache.totalCostLimit = 50 * 1024 * 1024 // 50 MB
 
-        let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let cacheDir = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
         cacheDirectory = cacheDir.appendingPathComponent("cover_art")
         try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
     }

--- a/Primuse/Views/Components/CachedArtworkView.swift
+++ b/Primuse/Views/Components/CachedArtworkView.swift
@@ -544,9 +544,9 @@ struct CachedArtworkView: View {
             return cg.bytesPerRow * cg.height
         }
         #if os(iOS)
-        return Int(image.size.width * image.size.height * image.scale * image.scale * 4)
+        return (image.size.width * image.size.height * image.scale * image.scale * 4).finiteInt()
         #else
-        return Int(image.size.width * image.size.height * 4)
+        return (image.size.width * image.size.height * 4).finiteInt()
         #endif
     }
 

--- a/Primuse/Views/Library/PlaylistDetailView.swift
+++ b/Primuse/Views/Library/PlaylistDetailView.swift
@@ -525,7 +525,7 @@ struct PlaylistDetailView: View {
             Color(red: 0.4, green: 0.7, blue: 0.95),
             Color(red: 0.7, green: 0.6, blue: 0.95),
         ]
-        let h = abs(source.type.rawValue.hashValue) % palette.count
+        let h = source.type.rawValue.utf8.reduce(0) { ($0 + Int($1)) % palette.count }
         return palette[h]
     }
     #endif

--- a/Primuse/Views/Library/SongListView.swift
+++ b/Primuse/Views/Library/SongListView.swift
@@ -1069,7 +1069,7 @@ struct SongListView: View {
             Color(red: 0.4, green: 0.7, blue: 0.95),
             Color(red: 0.7, green: 0.6, blue: 0.95),
         ]
-        let h = abs(source.type.rawValue.hashValue) % palette.count
+        let h = source.type.rawValue.utf8.reduce(0) { ($0 + Int($1)) % palette.count }
         return palette[h]
     }
 
@@ -1156,7 +1156,10 @@ struct SongListView: View {
             recomputeSorted()
             return
         }
-        let byID = Dictionary(uniqueKeysWithValues: songs.map { ($0.id, $0) })
+        let byID = Dictionary(
+            songs.map { ($0.id, $0) },
+            uniquingKeysWith: { current, _ in current }
+        )
         let sortKeyChanged = cachedSortedSongs.contains { old in
             guard let new = byID[old.id] else { return false }
             return sortKey(for: new) != sortKey(for: old)

--- a/Primuse/Views/Library/TagEditorView.swift
+++ b/Primuse/Views/Library/TagEditorView.swift
@@ -368,7 +368,7 @@ struct TagEditorView: View {
 
     private var macDurationText: String {
         guard song.duration > 0 else { return "—" }
-        let total = Int(song.duration.rounded())
+        let total = song.duration.rounded().finiteInt()
         return String(format: "%d:%02d", total / 60, total % 60)
     }
 

--- a/Primuse/Views/Mac/MacHomeView.swift
+++ b/Primuse/Views/Mac/MacHomeView.swift
@@ -556,7 +556,7 @@ struct MacHomeView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else {
                     taskProgressBar(progress)
-                    Text(verbatim: "\(Int(min(max(progress, 0), 1) * 100))%")
+                    Text(verbatim: "\((min(max(progress, 0), 1) * 100).finiteInt())%")
                         .font(.system(size: 10.5, weight: .medium, design: .monospaced))
                         .foregroundStyle(PMColor.textMuted)
                         .monospacedDigit()
@@ -1197,7 +1197,7 @@ private struct MacHomeSourceStatusCard: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else {
                     progressBar(progress)
-                    Text(verbatim: "\(Int(min(max(progress, 0), 1) * 100))%")
+                    Text(verbatim: "\((min(max(progress, 0), 1) * 100).finiteInt())%")
                         .font(.system(size: 10.5, weight: .medium, design: .monospaced))
                         .foregroundStyle(PMColor.textMuted)
                         .monospacedDigit()

--- a/Primuse/Views/Mac/MacMiniPlayerView.swift
+++ b/Primuse/Views/Mac/MacMiniPlayerView.swift
@@ -676,7 +676,7 @@ private struct MacMiniPlayerProgress: View {
 
     private func formatTime(_ time: TimeInterval) -> String {
         guard time.isFinite, time >= 0 else { return "0:00" }
-        let total = Int(time)
+        let total = time.finiteInt()
         return String(format: "%d:%02d", total / 60, total % 60)
     }
 }

--- a/Primuse/Views/Mac/MacNowPlayingView.swift
+++ b/Primuse/Views/Mac/MacNowPlayingView.swift
@@ -627,7 +627,7 @@ struct MacNowPlayingView: View {
             ), accessibilityLabel: String(localized: "volume"))
             .frame(width: 118)
 
-            Text(verbatim: "\(Int((engine.volume * 100).rounded()))")
+            Text(verbatim: "\((engine.volume * 100).rounded().finiteInt())")
                 .font(.system(size: 11, weight: .medium, design: .monospaced))
                 .monospacedDigit()
                 .foregroundStyle(.white.opacity(0.62))

--- a/Primuse/Views/Mac/MacSettingsView.swift
+++ b/Primuse/Views/Mac/MacSettingsView.swift
@@ -444,7 +444,7 @@ private struct MacSTSlider: View {
     init(value: Binding<Double>,
          in range: ClosedRange<Double> = 0...100,
          width: CGFloat = 200,
-         formatter: @escaping (Double) -> String = { "\(Int($0.rounded()))" }) {
+         formatter: @escaping (Double) -> String = { "\($0.rounded().finiteInt())" }) {
         self._value = value
         self.range = range
         self.width = width
@@ -683,10 +683,10 @@ private struct MacSTPlaybackView: View {
                         MacSTSlider(
                             value: Binding(
                                 get: { Double(s.prewarmQueueCount) },
-                                set: { s.prewarmQueueCount = Int($0.rounded()) }
+                                set: { s.prewarmQueueCount = $0.rounded().finiteInt() }
                             ),
                             in: 0...8,
-                            formatter: { "\(Int($0.rounded()))" }
+                            formatter: { "\($0.rounded().finiteInt())" }
                         )
                     }
                 }
@@ -743,7 +743,7 @@ private struct MacSTEqualizerView: View {
         MacEQFaderCard(
             bands: eq.bandFrequencyLabels,
             gains: Binding(
-                get: { eq.bands.map { Int($0.rounded()) } },
+                get: { eq.bands.map { $0.rounded().finiteInt() } },
                 set: { newGains in
                     for (i, g) in newGains.enumerated() {
                         eq.setBand(i, gain: Float(g))
@@ -847,7 +847,7 @@ private struct MacEQFader: View {
                         guard let start = dragStartGain else { return }
                         // 上拖 (negative y) → 增益变高
                         let deltaDB = -g.translation.height / dbPerPoint
-                        gain = max(-12, min(12, start + Int(deltaDB.rounded())))
+                        gain = max(-12, min(12, start + deltaDB.rounded().finiteInt()))
                     }
                     .onEnded { _ in dragStartGain = nil }
             )
@@ -1058,7 +1058,7 @@ private struct MacSTScrapingView: View {
                     MacSTSlider(
                         value: $sidecarWriteTimeout,
                         in: 5...120,
-                        formatter: { "\(Int($0.rounded()))s" }
+                        formatter: { "\($0.rounded().finiteInt())s" }
                     )
                 }
             }
@@ -1523,7 +1523,7 @@ private struct MacScraperImportPreview {
 
     var rateLimitText: String {
         guard let rateLimitMs, rateLimitMs > 0 else { return "60 rpm · burst 8" }
-        let rpm = max(1, Int((60_000.0 / Double(rateLimitMs)).rounded()))
+        let rpm = max(1, (60_000.0 / Double(rateLimitMs)).rounded().finiteInt(or: 1))
         return "\(rpm) rpm · burst 8"
     }
 
@@ -2303,7 +2303,7 @@ enum MacWidgetDataPublisher {
         let summary = store.summary(in: .year)
         WrappedSnapshot(
             year: year,
-            totalHours: Int((summary.totalSec / 3600).rounded()),
+            totalHours: (summary.totalSec / 3600).rounded().finiteInt(),
             topArtist: store.topArtists(in: .year, limit: 1).first?.title,
             topSong: store.topSongs(in: .year, limit: 1).first?.title
         ).save()

--- a/Primuse/Views/Mac/MacSidebar.swift
+++ b/Primuse/Views/Mac/MacSidebar.swift
@@ -513,7 +513,7 @@ struct MacSidebar: View {
             Color(red: 0.4, green: 0.7, blue: 0.95),  // sky
             Color(red: 0.7, green: 0.6, blue: 0.95),  // lilac
         ]
-        let h = abs(source.type.rawValue.hashValue) % palette.count
+        let h = source.type.rawValue.utf8.reduce(0) { ($0 + Int($1)) % palette.count }
         return palette[h]
     }
 

--- a/Primuse/Views/Mac/MenuBarPlayerView.swift
+++ b/Primuse/Views/Mac/MenuBarPlayerView.swift
@@ -194,7 +194,7 @@ struct MenuBarPlayerView: View {
             )
             .controlSize(.mini)
             .tint(PMColor.text.opacity(0.7))
-            Text(String(format: "%d", Int(engine.volume * 100)))
+            Text(String(format: "%d", Double(engine.volume * 100).finiteInt()))
                 .font(.system(size: 10, design: .monospaced))
                 .monospacedDigit()
                 .foregroundStyle(PMColor.textFaint)
@@ -276,7 +276,7 @@ private struct MenuBarPlayerProgress: View {
 
     private func formatTime(_ time: TimeInterval) -> String {
         guard time.isFinite, time >= 0 else { return "0:00" }
-        let total = Int(time)
+        let total = time.finiteInt()
         return String(format: "%d:%02d", total / 60, total % 60)
     }
 }

--- a/Primuse/Views/Mac/PlayerMoreMenu.swift
+++ b/Primuse/Views/Mac/PlayerMoreMenu.swift
@@ -640,14 +640,14 @@ private struct MacSleepTimerPopover: View {
 
     private var selectedPreset: Int? {
         guard let end = player.sleepTimerEndDate else { return nil }
-        let minutes = Int(round(end.timeIntervalSince(now) / 60.0))
+        let minutes = round(end.timeIntervalSince(now) / 60.0).finiteInt()
         return presets.min(by: { abs($0 - minutes) < abs($1 - minutes) })
             .flatMap { abs($0 - minutes) <= 1 ? $0 : nil }
     }
 
     private var statusText: String {
         if let end = player.sleepTimerEndDate {
-            let remaining = max(0, Int(end.timeIntervalSince(now)))
+            let remaining = max(0, end.timeIntervalSince(now).finiteInt())
             return "\(Lz("Remaining")) \(TimeInterval(remaining).formattedDuration)"
         }
         if player.sleepStopAfterSongID != nil {
@@ -687,7 +687,7 @@ struct MacSimilarSongsPopover: View {
         let song: Song
         let affinity: Double
         var id: String { song.id }
-        var score: Int { min(99, max(1, Int((affinity * 100).rounded()))) }
+        var score: Int { min(99, max(1, (affinity * 100).rounded().finiteInt(or: 1))) }
     }
 
     /// 全库相似度计算 (较重) —— 只在 seed 变化时算一次, 结果缓存到 `localRows`。

--- a/Primuse/Views/NowPlaying/NowPlayingView.swift
+++ b/Primuse/Views/NowPlaying/NowPlayingView.swift
@@ -2516,7 +2516,9 @@ struct LyricsScrollView: View {
     private func scheduleWordAutoFollowResume() {
         wordAutoFollowResumeTask?.cancel()
         wordAutoFollowResumeTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: UInt64(Self.manualScrollGracePeriod * 1_000_000_000))
+            let nanoseconds = (Self.manualScrollGracePeriod * 1_000_000_000)
+                .finiteUInt64(or: 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanoseconds)
             guard !Task.isCancelled else { return }
             guard Date().timeIntervalSince(lastUserScrollTime) >= Self.manualScrollGracePeriod else { return }
             wordDragStartOffset = wordAutoOffset

--- a/Primuse/Views/NowPlaying/ScrapeOptionsView.swift
+++ b/Primuse/Views/NowPlaying/ScrapeOptionsView.swift
@@ -353,7 +353,7 @@ struct ScrapeOptionsView: View {
                 Spacer(minLength: 6)
 
                 VStack(alignment: .trailing, spacing: 2) {
-                    Text(verbatim: "\(Int((item.confidence * 100).rounded()))%")
+                    Text(verbatim: "\((item.confidence * 100).rounded().finiteInt())%")
                         .font(.system(size: 11, weight: .semibold, design: .monospaced))
                         .foregroundStyle(item.confidence > 0.9 ? PMColor.ok : PMColor.brand)
                     if item.sourceConfig.type.supportsWordLevelLyrics {
@@ -1595,7 +1595,8 @@ struct ScrapeOptionsView: View {
                 await applyResult(writeResult)
             }
             group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                let nanoseconds = (seconds * 1_000_000_000).finiteUInt64(or: 30_000_000_000)
+                try await Task.sleep(nanoseconds: nanoseconds)
                 throw CancellationError()
             }
             // 等任意一个先完成。如果是真实工作完成 → 第二个 sleep task 被 cancelAll
@@ -1617,7 +1618,7 @@ struct ScrapeOptionsView: View {
         var maxScore = 0.0
 
         let targetMs = song.duration.sanitizedDuration > 0
-            ? Int((song.duration.sanitizedDuration * 1000).rounded())
+            ? (song.duration.sanitizedDuration * 1000).rounded().finiteInt()
             : nil
         if let target = targetMs, let ms = durationMs {
             maxScore += 50

--- a/Primuse/Views/Settings/ListeningStatsView.swift
+++ b/Primuse/Views/Settings/ListeningStatsView.swift
@@ -161,7 +161,7 @@ struct ListeningStatsView: View {
         let counts = snapshot.dailyCounts
         let days = max(counts.count, 1)
         let totalMin = Int(s.totalSec / 60)
-        let coverage = Int((Double(s.activeDays) / Double(days) * 100).rounded())
+        let coverage = (Double(s.activeDays) / Double(days) * 100).rounded().finiteInt()
         let coverLabel = (range == .week || range == .month) ? "覆盖率" : "全年覆盖率"
         return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 14), count: 4), spacing: 14) {
             macSummaryCell(value: decimal(s.totalPlays),
@@ -212,7 +212,9 @@ struct ListeningStatsView: View {
             return "全部历史累计"
         }
         guard previous > 0 else { return "暂无往期对比" }
-        let pct = Int((Double(current - previous) / Double(previous) * 100).rounded())
+        let pct = ((Double(current) - Double(previous)) / Double(previous) * 100)
+            .rounded()
+            .finiteInt()
         let vs: String
         switch range {
         case .week:  vs = "上周"
@@ -770,9 +772,9 @@ struct ListeningStatsView: View {
 
     private func formatHours(_ sec: TimeInterval) -> String {
         if sec < 60 {
-            return String(format: String(localized: "stats_seconds_format"), Int(sec))
+            return String(format: String(localized: "stats_seconds_format"), sec.finiteInt())
         }
-        let totalMin = Int(sec / 60)
+        let totalMin = (sec / 60).finiteInt()
         if totalMin < 60 {
             return String(format: String(localized: "stats_minutes_format"), totalMin)
         }

--- a/Primuse/Views/Settings/SettingsView.swift
+++ b/Primuse/Views/Settings/SettingsView.swift
@@ -827,9 +827,9 @@ struct PlaybackSettingsView: View {
                         Text("crossfade_duration")
                             .font(.caption)
                         Slider(value: $settings.crossfadeDuration, in: 1...12, step: 1) {
-                            Text("\(Int(settings.crossfadeDuration))s")
+                            Text("\(settings.crossfadeDuration.finiteInt())s")
                         }
-                        Text("\(Int(settings.crossfadeDuration)) \(String(localized: "seconds"))")
+                        Text("\(settings.crossfadeDuration.finiteInt()) \(String(localized: "seconds"))")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }

--- a/Primuse/Views/YearlyReport/YearlyReportCards.swift
+++ b/Primuse/Views/YearlyReport/YearlyReportCards.swift
@@ -199,7 +199,7 @@ struct OverviewCard: View {
     }
 
     private func growthText(_ growth: Double) -> String {
-        let pct = Int(abs(growth * 100))
+        let pct = abs(growth * 100).finiteInt()
         if growth > 0.05 {
             return String(format: String(localized: "yearly_card_growth_more_format"), pct)
         } else if growth < -0.05 {
@@ -664,7 +664,7 @@ struct ExplorationCard: View {
     let data: YearlyReportData
 
     private var focusPercent: Int {
-        Int((data.explorationTopArtistShare * 100).rounded())
+        (data.explorationTopArtistShare * 100).rounded().finiteInt()
     }
 
     private var explorationPercent: Int {
@@ -914,8 +914,8 @@ struct ClosingCard: View {
 // MARK: - Helpers
 
 private func formatDuration(_ seconds: TimeInterval) -> String {
-    let h = Int(seconds / 3600)
-    let m = Int(seconds.truncatingRemainder(dividingBy: 3600) / 60)
+    let h = (seconds / 3600).finiteInt()
+    let m = (seconds.truncatingRemainder(dividingBy: 3600) / 60).finiteInt()
     if h > 0 { return String(format: String(localized: "yearly_duration_hm_format"), h, m) }
     return String(format: String(localized: "yearly_duration_minutes_format"), m)
 }

--- a/Primuse/Views/YearlyReport/YearlyReportView.swift
+++ b/Primuse/Views/YearlyReport/YearlyReportView.swift
@@ -377,7 +377,7 @@ struct YearlyReportView: View {
                     names.isEmpty ? String(localized: "yearly_meta_genres_sub_empty") : String(localized: "yearly_meta_genres_sub"),
                     "guitars", false)
         case .exploration:
-            let focus = Int((data.explorationTopArtistShare * 100).rounded())
+            let focus = (data.explorationTopArtistShare * 100).rounded().finiteInt()
             let exploration = max(0, 100 - focus)
             let tendency = data.personality?.exploration == .explorer
                 ? String(localized: "yearly_exploration_explorer")
@@ -431,8 +431,8 @@ struct YearlyReportView: View {
 
     private func formatDuration(_ sec: TimeInterval) -> String {
         guard sec > 0 else { return String(localized: "yearly_duration_zero") }
-        let hours = Int(sec / 3600)
-        let minutes = Int(sec.truncatingRemainder(dividingBy: 3600) / 60)
+        let hours = (sec / 3600).finiteInt()
+        let minutes = (sec.truncatingRemainder(dividingBy: 3600) / 60).finiteInt()
         if hours > 0 { return String(format: String(localized: "yearly_duration_hm_format"), hours, minutes) }
         return String(format: String(localized: "yearly_duration_minutes_format"), minutes)
     }

--- a/PrimuseKit/Sources/PrimuseKit/Metadata/ID3TextMetadataParser.swift
+++ b/PrimuseKit/Sources/PrimuseKit/Metadata/ID3TextMetadataParser.swift
@@ -222,19 +222,21 @@ public enum ID3TextMetadataParser {
     }
 
     private static func ascii(_ data: Data, at offset: Int, count: Int) -> String? {
-        guard offset >= 0, count >= 0, offset + count <= data.count else { return nil }
+        guard offset >= 0, count >= 0, offset <= data.count, count <= data.count - offset else {
+            return nil
+        }
         return String(data: data.subdata(in: offset..<(offset + count)), encoding: .isoLatin1)
     }
 
     private static func uint24BE(_ data: Data, at offset: Int) -> Int {
-        guard offset + 3 <= data.count else { return 0 }
+        guard offset >= 0, offset <= data.count - 3 else { return 0 }
         return (Int(data[offset]) << 16)
             | (Int(data[offset + 1]) << 8)
             | Int(data[offset + 2])
     }
 
     private static func uint32BE(_ data: Data, at offset: Int) -> Int {
-        guard offset + 4 <= data.count else { return 0 }
+        guard offset >= 0, offset <= data.count - 4 else { return 0 }
         return (Int(data[offset]) << 24)
             | (Int(data[offset + 1]) << 16)
             | (Int(data[offset + 2]) << 8)
@@ -242,7 +244,7 @@ public enum ID3TextMetadataParser {
     }
 
     private static func syncSafeInt(_ data: Data, at offset: Int) -> Int {
-        guard offset + 4 <= data.count else { return 0 }
+        guard offset >= 0, offset <= data.count - 4 else { return 0 }
         return (Int(data[offset] & 0x7F) << 21)
             | (Int(data[offset + 1] & 0x7F) << 14)
             | (Int(data[offset + 2] & 0x7F) << 7)

--- a/PrimuseKit/Sources/PrimuseKit/Models/WidgetSnapshots.swift
+++ b/PrimuseKit/Sources/PrimuseKit/Models/WidgetSnapshots.swift
@@ -221,7 +221,7 @@ public struct ListeningStatsSnapshot: Codable, Sendable {
         self.updatedAt = updatedAt
     }
 
-    public var totalHours: Int { Int((totalSeconds / 3600).rounded()) }
+    public var totalHours: Int { (totalSeconds / 3600).rounded().finiteInt() }
 
     public static func load() -> ListeningStatsSnapshot? {
         WidgetSharedStore.load(ListeningStatsSnapshot.self, key: PrimuseConstants.listeningStatsKey)

--- a/PrimuseKit/Sources/PrimuseKit/SharedConstants.swift
+++ b/PrimuseKit/Sources/PrimuseKit/SharedConstants.swift
@@ -161,6 +161,62 @@ public enum SafeJSONSerialization {
     }
 }
 
+public extension BinaryFloatingPoint {
+    /// Converts a floating-point value to `Int` without allowing malformed
+    /// metadata (`NaN`, infinity, or an out-of-range finite value) to trap.
+    /// Callers can choose a domain-appropriate fallback; durations normally
+    /// use zero so an invalid value is treated as unknown.
+    func finiteInt(or fallback: Int = 0) -> Int {
+        let value = Double(self)
+        guard value.isFinite,
+              value >= Double(Int.min),
+              value < Double(Int.max) else {
+            return fallback
+        }
+        return Int(value)
+    }
+
+    /// Converts a floating-point value to `UInt64` without trapping on
+    /// negative, non-finite, or out-of-range timeout/configuration values.
+    func finiteUInt64(or fallback: UInt64 = 0) -> UInt64 {
+        let value = Double(self)
+        guard value.isFinite,
+              value >= 0,
+              value < Double(UInt64.max) else {
+            return fallback
+        }
+        return UInt64(value)
+    }
+}
+
+public extension FileManager {
+    /// Search-path APIs normally return one URL on Apple platforms, but using
+    /// `.first!` turns an unusual container/filesystem failure into a process
+    /// trap. Temporary storage is a safe last-resort location for startup.
+    func primuseDirectoryURL(for directory: SearchPathDirectory) -> URL {
+        urls(for: directory, in: .userDomainMask).first ?? temporaryDirectory
+    }
+}
+
+public enum SafeByteRange {
+    /// Returns the exclusive end for a non-negative byte range, or `nil`
+    /// when the range is empty, negative, or would overflow `Int64`.
+    public static func exclusiveEnd(offset: Int64, length: Int64) -> Int64? {
+        guard offset >= 0, length > 0 else { return nil }
+        let (end, overflow) = offset.addingReportingOverflow(length)
+        guard !overflow, end > offset else { return nil }
+        return end
+    }
+
+    /// RFC 7233 Range header. Negative offsets use suffix-range syntax.
+    public static func httpHeader(offset: Int64, length: Int64) -> String? {
+        guard length > 0 else { return nil }
+        if offset < 0 { return "bytes=\(offset)" }
+        guard let end = exclusiveEnd(offset: offset, length: length) else { return nil }
+        return "bytes=\(offset)-\(end - 1)"
+    }
+}
+
 public enum PrimuseConstants {
     public static let appGroupIdentifier = "group.com.welape.yuanyin"
     public static let playbackStateKey = "playbackState"

--- a/PrimuseKit/Tests/PrimuseKitTests/PrimuseKitTests.swift
+++ b/PrimuseKit/Tests/PrimuseKitTests/PrimuseKitTests.swift
@@ -31,6 +31,27 @@ import Testing
     #expect(didThrow)
 }
 
+@Test func finiteIntRejectsNonFiniteAndOutOfRangeValues() {
+    #expect(42.9.finiteInt() == 42)
+    #expect(Double.nan.finiteInt() == 0)
+    #expect(Double.infinity.finiteInt(or: 7) == 7)
+    #expect(Double(Int.max).finiteInt(or: 9) == 9)
+    #expect(Double(Int.min).finiteInt() == Int.min)
+    #expect(Float(42.9).finiteInt() == 42)
+    #expect(Float.nan.finiteInt(or: 3) == 3)
+    #expect((-1.0).finiteUInt64(or: 5) == 5)
+    #expect(Double.infinity.finiteUInt64(or: 6) == 6)
+}
+
+@Test func safeByteRangeRejectsInvalidAndOverflowingRanges() {
+    #expect(SafeByteRange.exclusiveEnd(offset: 10, length: 5) == 15)
+    #expect(SafeByteRange.exclusiveEnd(offset: -1, length: 5) == nil)
+    #expect(SafeByteRange.exclusiveEnd(offset: Int64.max - 1, length: 2) == nil)
+    #expect(SafeByteRange.httpHeader(offset: 10, length: 5) == "bytes=10-14")
+    #expect(SafeByteRange.httpHeader(offset: -5, length: 5) == "bytes=-5")
+    #expect(SafeByteRange.httpHeader(offset: 0, length: 0) == nil)
+}
+
 @Test func testAudioFormatRouting() {
     #expect(AudioFormat.mp3.requiresFFmpeg == false)
     #expect(AudioFormat.flac.requiresFFmpeg == false)

--- a/PrimuseTV/Audio/TVPlaybackCoordinator.swift
+++ b/PrimuseTV/Audio/TVPlaybackCoordinator.swift
@@ -23,7 +23,7 @@ enum TVPlaybackIssue: Equatable {
 /// 把真实歌曲解析成网络流 URL 并交给 AVPlayer;解析失败转成可展示的 TVPlaybackIssue。
 @MainActor
 final class TVPlaybackCoordinator {
-    private unowned let store: TVStore
+    private weak var store: TVStore?
     private let engine: TVAudioEngine
     private let registry = StreamResolverRegistry.shared
 
@@ -38,6 +38,9 @@ final class TVPlaybackCoordinator {
         startAt: Double = 0,
         autoPlay: Bool = true
     ) async {
+        // Keep the store alive for the whole asynchronous playback setup. A queued
+        // task may otherwise outlive TVStore and turn an `unowned` access into a trap.
+        guard let store else { return }
         store.playbackIssue = nil
         guard let song = store.library.song(id: songID) else {
             plog("🎬 TV play: song not found id=\(songID)")
@@ -185,6 +188,7 @@ final class TVPlaybackCoordinator {
         startAt: Double,
         autoPlay: Bool
     ) async {
+        guard let store else { return }
         do {
             let tempURL = try await downloadToTemp(song: song, source: source, credential: credential, ext: ext)
             engine.loadDecoded(fileURL: tempURL, title: song.title, artist: song.artistName ?? "",

--- a/PrimuseTV/Audio/TVStreamResourceLoader.swift
+++ b/PrimuseTV/Audio/TVStreamResourceLoader.swift
@@ -1,6 +1,7 @@
 #if os(tvOS)
 import AVFoundation
 import Foundation
+import PrimuseKit
 import Security
 import UniformTypeIdentifiers
 
@@ -182,9 +183,17 @@ final class TVStreamResourceLoader: NSObject, AVAssetResourceLoaderDelegate, URL
                 // 拼进 Range 头也会被部分服务器拒为 416。改发开放式 Range(bytes=offset-)。
                 length = -1
             } else {
-                // 用 &+ 防御 requestedLength 极大时的加法溢出。
-                let requestedEnd = requestedStart &+ Int64(max(1, dataReq.requestedLength))
-                length = max(1, requestedEnd - offset)
+                let requestedLength = Int64(max(1, dataReq.requestedLength))
+                if let requestedEnd = SafeByteRange.exclusiveEnd(
+                    offset: requestedStart,
+                    length: requestedLength
+                ), requestedEnd > offset {
+                    length = requestedEnd - offset
+                } else {
+                    // An invalid/extreme request is safer as an open-ended
+                    // range than as wrapping signed arithmetic.
+                    length = -1
+                }
             }
         } else {
             offset = 0
@@ -192,8 +201,11 @@ final class TVStreamResourceLoader: NSObject, AVAssetResourceLoaderDelegate, URL
         }
         if length <= 0 {
             req.setValue("bytes=\(offset)-", forHTTPHeaderField: "Range")
+        } else if let rangeHeader = SafeByteRange.httpHeader(offset: offset, length: length) {
+            req.setValue(rangeHeader, forHTTPHeaderField: "Range")
         } else {
-            req.setValue("bytes=\(offset)-\(offset &+ length - 1)", forHTTPHeaderField: "Range")
+            loadingRequest.finishLoading(with: CocoaError(.fileReadInvalidFileName))
+            return false
         }
 
         let id = ObjectIdentifier(loadingRequest)
@@ -333,10 +345,12 @@ final class TVStreamResourceLoader: NSObject, AVAssetResourceLoaderDelegate, URL
             || http.value(forHTTPHeaderField: "Accept-Ranges")?.contains("bytes") == true
         // 优先用 Content-Range 的总长度(bytes a-b/total)
         if let range = http.value(forHTTPHeaderField: "Content-Range"),
-           let totalStr = range.split(separator: "/").last, let total = Int64(totalStr) {
+           let totalStr = range.split(separator: "/").last,
+           let total = Int64(totalStr), total >= 0 {
             info.contentLength = total
         } else if http.statusCode == 200,
-                  let lenStr = http.value(forHTTPHeaderField: "Content-Length"), let len = Int64(lenStr) {
+                  let lenStr = http.value(forHTTPHeaderField: "Content-Length"),
+                  let len = Int64(lenStr), len >= 0 {
             info.contentLength = len
         }
     }

--- a/PrimuseTV/Model/TVArtwork.swift
+++ b/PrimuseTV/Model/TVArtwork.swift
@@ -2,6 +2,7 @@
 import SwiftUI
 import UIKit
 import CryptoKit
+import PrimuseKit
 
 /// tvOS 封面加载:本地缓存 → iTunes Search API 在线取 → 落盘缓存。
 /// 本地曲库的封面缓存没同步到 tvOS,所以这里按「艺术家 + 专辑名」在线取真实封面;
@@ -13,7 +14,7 @@ actor TVArtworkLoader {
     private var negative: Set<String> = []   // 查不到的,本次会话不再反复请求
 
     private var cacheDir: URL {
-        let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let base = FileManager.default.primuseDirectoryURL(for: .cachesDirectory)
         let dir = base.appendingPathComponent("PrimuseTVArtwork", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir

--- a/PrimuseTV/Services/Protocol/FTPByteReader.swift
+++ b/PrimuseTV/Services/Protocol/FTPByteReader.swift
@@ -53,6 +53,9 @@ actor FTPByteReader: ByteRangeReader {
     }
 
     func read(offset: Int64, length: Int64) async throws -> Data {
+        guard SafeByteRange.exclusiveEnd(offset: offset, length: length) != nil else {
+            return Data()
+        }
         let path = filePath
         let p = provider
         let len = Int(min(max(0, length), Int64(Int.max)))

--- a/PrimuseTV/Services/Protocol/NFSByteReader.swift
+++ b/PrimuseTV/Services/Protocol/NFSByteReader.swift
@@ -73,9 +73,10 @@ actor NFSByteReader: ByteRangeReader {
     }
 
     func read(offset: Int64, length: Int64) async throws -> Data {
+        guard let end = SafeByteRange.exclusiveEnd(offset: offset, length: length) else {
+            return Data()
+        }
         let c = try await ensure()
-        let end = offset + max(0, length)
-        guard offset < end else { return Data() }
         let rel = relativePath
         return try await withCheckedThrowingContinuation { cont in
             c.contents(atPath: rel, range: offset..<end, progress: nil) { result in

--- a/PrimuseTV/Services/Protocol/SMBByteReader.swift
+++ b/PrimuseTV/Services/Protocol/SMBByteReader.swift
@@ -57,9 +57,10 @@ actor SMBByteReader: ByteRangeReader {
     }
 
     func read(offset: Int64, length: Int64) async throws -> Data {
+        guard let end = SafeByteRange.exclusiveEnd(offset: offset, length: length) else {
+            return Data()
+        }
         let m = try await ensure()
-        let end = offset + max(0, length)
-        guard offset < end else { return Data() }
         return try await m.contents(atPath: relativePath, range: UInt64(offset)..<UInt64(end))
     }
 

--- a/PrimuseTV/Views/TVHomeView.swift
+++ b/PrimuseTV/Views/TVHomeView.swift
@@ -15,7 +15,7 @@ struct TVHomeView: View {
     private var heroSongs: [TVSong] { store.songs(forAlbum: hero.id) }
     private var heroSubtitle: String {
         var parts = [PMString("ext.tv.songsCount", heroSongs.count)]
-        let mins = Int(heroSongs.reduce(0) { $0 + $1.duration } / 60)
+        let mins = (heroSongs.reduce(0) { $0 + $1.duration } / 60).finiteInt()
         if mins > 0 { parts.append(PMString("ext.tv.minCount", mins)) }
         if hero.year > 0 { parts.append("\(hero.year)") }
         parts.append(hero.artist)


### PR DESCRIPTION
## Summary

- reject non-finite and out-of-range numeric metadata instead of trapping during integer conversion
- validate HTTP, file, and AVFoundation byte ranges before arithmetic or slicing
- tolerate duplicate persisted identifiers and malformed smart-playlist, lyrics, and HTTP metadata
- remove production force unwraps and make the tvOS playback coordinator safe if its store is released

## Validation

- swift build in PrimuseKit
- focused finiteInt and SafeByteRange tests
- generic-device Debug builds for iOS, tvOS, and macOS
- final static scan for try-force, forced casts, fatal traps, unowned references, NSLog, and force-unwrapped collection values