### PR TITLE
fix(subsonic): show artwork for internet radio stations

### DIFF
--- a/Primuse/Services/Sources/SubsonicSource.swift
+++ b/Primuse/Services/Sources/SubsonicSource.swift
@@ -738,6 +738,7 @@ actor SubsonicSource: RefreshingMetadataSongConnector, ServerScrobblingConnector
                 name: name,
                 streamURL: station.streamURL,
                 homepageURL: station.homePageURL,
+                coverArtReference: station.coverArt.flatMap { coverArtURLString(for: $0) },
                 streamFormat: format
             )
         }
@@ -1268,10 +1269,12 @@ private struct SubsonicInternetRadioStation: Decodable {
     let name: String?
     let streamURL: String?
     let homePageURL: String?
+    let coverArt: String?
 
     enum CodingKeys: String, CodingKey {
         case id
         case name
+        case coverArt
         case streamURL = "streamUrl"
         case homePageURL = "homePageUrl"
     }


### PR DESCRIPTION
## Summary

- Decode the optional OpenSubsonic `coverArt` field returned by `getInternetRadioStations`
- Route the artwork ID through Primuse's existing authenticated Subsonic cover-art resolver
- Preserve the current placeholder when a server does not provide radio artwork

## Problem

Navidrome returns a `coverArt` ID for internet radio stations, but Primuse's `SubsonicInternetRadioStation` decoder did not declare that field and the radio mapping did not propagate it. As a result, mirrored Navidrome radio stations always displayed the generic placeholder even when their artwork was available in Navidrome.

The field is optional in OpenSubsonic, so legacy Subsonic/Airsonic responses remain compatible.

## Validation

- `swiftc -frontend -parse Primuse/Services/Sources/SubsonicSource.swift`
- Decoded a representative Navidrome/OpenSubsonic radio response containing `"coverArt": "ra-rd-1"`
- `swift test --package-path PrimuseKit --filter RadioStationTests` compiled the package sources, then could not compile the test target because the installed command-line toolchain has no `Testing` module

A full app build was not available because this machine has Swift command-line tools but no full Xcode installation.