### PR TITLE
fix(subsonic): support OpenSubsonic v2 word lyrics

### DIFF
--- a/Primuse/Services/Sources/SubsonicSource.swift
+++ b/Primuse/Services/Sources/SubsonicSource.swift
@@ -681,25 +681,30 @@ actor SubsonicSource: RefreshingMetadataSongConnector, ServerScrobblingConnector
 
     /// OpenSubsonic getLyricsBySongId —— 结构化(可带时间轴)歌词。
     private func modernLyrics(songID: String) async -> String? {
-        // requestJSON 在 status != "ok" 时抛错, try? 吞掉后返回 nil。
-        guard let container: LyricsContainer = try? await requestJSON(
+        // songLyrics v2 gates cue-level karaoke timing behind enhanced=true.
+        // Most older servers ignore the optional parameter and keep returning
+        // the version 1 line array. If one rejects unknown parameters, retry
+        // the original request so enabling karaoke does not regress lyrics.
+        let enhanced: LyricsContainer? = try? await requestJSON(
+            "getLyricsBySongId",
+            query: [
+                URLQueryItem(name: "id", value: songID),
+                URLQueryItem(name: "enhanced", value: "true"),
+            ]
+        )
+        let container: LyricsContainer
+        if let enhanced {
+            container = enhanced
+        } else if let versionOne: LyricsContainer = try? await requestJSON(
             "getLyricsBySongId",
             query: [URLQueryItem(name: "id", value: songID)]
-        ),
-        let structured = container.lyricsList?.structuredLyrics?.first,
-        let lines = structured.line, !lines.isEmpty else {
+        ) {
+            container = versionOne
+        } else {
             return nil
         }
-        // 按"行是否带 start 时间戳"判定是否同步, 不依赖 `synced` 标志 ——
-        // 实测 Navidrome 0.61 对部分曲目返回带时间轴的 line[] 却不给 synced
-        // 字段(已知 bug)。有时间戳的行输出 LRC `[mm:ss.xx]`, 无时间戳的输出
-        // 裸文本, 交给 LyricsParser.parseText 统一处理(它兼容 LRC 与纯文本)。
-        let text = lines.compactMap { line -> String? in
-            guard let value = line.value, !value.isEmpty else { return nil }
-            if let start = line.start { return "\(Self.lrcTimestamp(ms: start))\(value)" }
-            return value
-        }.joined(separator: "\n")
-        return text.isEmpty ? nil : text
+        guard let tracks = container.lyricsList?.structuredLyrics else { return nil }
+        return OpenSubsonicLyricsConverter.text(from: tracks)
     }
 
     /// 老 Subsonic getLyrics —— 按 artist+title 匹配, 只返回无时间轴纯文本。
@@ -1182,15 +1187,6 @@ actor SubsonicSource: RefreshingMetadataSongConnector, ServerScrobblingConnector
         SHA256.hash(data: Data(value.utf8)).prefix(16).map { String(format: "%02x", $0) }.joined()
     }
 
-    private static func lrcTimestamp(ms: Int) -> String {
-        let totalCentis = ms / 10
-        let centis = totalCentis % 100
-        let totalSeconds = totalCentis / 100
-        let seconds = totalSeconds % 60
-        let minutes = totalSeconds / 60
-        return String(format: "[%02d:%02d.%02d]", minutes, seconds, centis)
-    }
-
     private static func parseDate(_ value: String) -> Date? {
         let fractional = ISO8601DateFormatter()
         fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -1497,15 +1493,5 @@ private struct LyricsContainer: SubsonicResponseContainer {
 }
 
 private struct LyricsList: Decodable {
-    let structuredLyrics: [StructuredLyrics]?
-}
-
-private struct StructuredLyrics: Decodable {
-    let synced: Bool?
-    let line: [StructuredLyricLine]?
-}
-
-private struct StructuredLyricLine: Decodable {
-    let start: Int?     // 毫秒
-    let value: String?
+    let structuredLyrics: [OpenSubsonicLyricsConverter.Track]?
 }

--- a/PrimuseKit/Sources/PrimuseKit/Models/LyricLine.swift
+++ b/PrimuseKit/Sources/PrimuseKit/Models/LyricLine.swift
@@ -914,11 +914,14 @@ public enum LyricsContentParser {
         }
 
         guard !syllables.isEmpty else { return nil }
-        for index in 0..<(syllables.count - 1) where syllables[index].end <= syllables[index].start {
+        // Relative A2/KRC marks carry an explicit duration. A zero duration is
+        // valid (for example, an instantaneous OpenSubsonic cue), so only
+        // repair genuinely invalid negative ranges here.
+        for index in 0..<(syllables.count - 1) where syllables[index].end < syllables[index].start {
             syllables[index].end = syllables[index + 1].start
         }
         if let lastIndex = syllables.indices.last,
-           syllables[lastIndex].end <= syllables[lastIndex].start {
+           syllables[lastIndex].end < syllables[lastIndex].start {
             syllables[lastIndex].end = syllables[lastIndex].start + 0.4
         }
 

--- a/PrimuseKit/Sources/PrimuseKit/OpenSubsonicLyrics.swift
+++ b/PrimuseKit/Sources/PrimuseKit/OpenSubsonicLyrics.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+/// Decodes songLyrics v2 cue timing and converts it to the relative A2 LRC
+/// representation already understood by Primuse's shared lyrics parser.
+public enum OpenSubsonicLyricsConverter {
+    public struct Track: Decodable, Sendable {
+        public let kind: String?
+        public let synced: Bool?
+        public let offset: Int?
+        public let line: [Line]?
+        public let cueLine: [CueLine]?
+    }
+
+    public struct Line: Decodable, Sendable {
+        public let start: Int?
+        public let value: String?
+    }
+
+    public struct CueLine: Decodable, Sendable {
+        public let index: Int?
+        public let start: Int?
+        public let end: Int?
+        public let value: String?
+        public let cue: [Cue]?
+    }
+
+    public struct Cue: Decodable, Sendable {
+        public let start: Int?
+        public let end: Int?
+        public let value: String?
+        public let byteStart: Int?
+        public let byteEnd: Int?
+    }
+
+    public static func text(from tracks: [Track]) -> String? {
+        let candidates = tracks.filter { !($0.line ?? []).isEmpty }
+        let main = candidates.filter { normalizedKind($0.kind) == "main" }
+        let track = main.first(where: hasRenderableCues)
+            ?? main.first
+            ?? candidates.first(where: hasRenderableCues)
+            ?? candidates.first
+        guard let track, let lines = track.line else {
+            return nil
+        }
+
+        let timingOffset = track.offset ?? 0
+        // ServerLyricsConnector exposes one lyrics document. The v2 contract
+        // orders the main cueLine first when an index has multiple vocal
+        // agents, so render that lead layer and leave parallel background
+        // layers out instead of interleaving their text.
+        let cuesByIndex = Dictionary(grouping: track.cueLine ?? []) { $0.index ?? -1 }
+        var output: [String] = []
+        for (index, line) in lines.enumerated() {
+            let nextLineStart = lines.indices.contains(index + 1)
+                ? lines[index + 1].start.map { adjustedTimestamp($0, offset: timingOffset) }
+                : nil
+            if track.synced != false,
+               let cueLine = cuesByIndex[index]?.first,
+               let text = serialize(
+                   cueLine,
+                   parent: line,
+                   nextLineStart: nextLineStart,
+                   timingOffset: timingOffset
+               ) {
+                output.append(text)
+            } else if let value = lineValue(line.value) {
+                output.append(
+                    line.start.map {
+                        lrcTimestamp(adjustedTimestamp($0, offset: timingOffset)) + value
+                    } ?? value
+                )
+            }
+        }
+
+        let result = output.joined(separator: "\n")
+        return result.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : result
+    }
+
+    private static func hasRenderableCues(_ track: Track) -> Bool {
+        track.synced != false && (track.cueLine ?? []).contains { cueLine in
+            (cueLine.cue ?? []).contains { cue in
+                cue.start != nil && !(cue.value ?? "").isEmpty
+            }
+        }
+    }
+
+    private static func serialize(
+        _ cueLine: CueLine,
+        parent: Line,
+        nextLineStart: Int?,
+        timingOffset: Int
+    ) -> String? {
+        let cues = (cueLine.cue ?? []).enumerated().compactMap { order, cue -> TimedCue? in
+            guard let start = cue.start, start >= 0,
+                  let value = cue.value, !value.isEmpty else { return nil }
+            return TimedCue(
+                order: order,
+                start: adjustedTimestamp(start, offset: timingOffset),
+                end: cue.end.map { adjustedTimestamp($0, offset: timingOffset) },
+                value: value,
+                byteStart: cue.byteStart,
+                byteEnd: cue.byteEnd
+            )
+        }.sorted {
+            $0.start == $1.start ? $0.order < $1.order : $0.start < $1.start
+        }
+        guard !cues.isEmpty,
+              cues.contains(where: { !$0.value.trimmingCharacters(in: .whitespaces).isEmpty }) else {
+            return nil
+        }
+
+        let declaredLineStart = (cueLine.start ?? parent.start).map {
+            adjustedTimestamp($0, offset: timingOffset)
+        }
+        let lineStart = min(declaredLineStart ?? cues[0].start, cues[0].start)
+        let lineEnd = cueLine.end.map { adjustedTimestamp($0, offset: timingOffset) }
+            ?? cues.compactMap(\.end).max()
+            ?? nextLineStart
+            ?? addingMilliseconds(400, to: cues.last!.start)
+        let values = resolvedValues(for: cues, canonicalLine: cueLine.value)
+        let body: String = cues.enumerated().map { index, cue -> String in
+            let end = cue.end
+                ?? (cues.indices.contains(index + 1) ? cues[index + 1].start : nil)
+                ?? cueLine.end.map { adjustedTimestamp($0, offset: timingOffset) }
+                ?? nextLineStart
+                ?? addingMilliseconds(400, to: cue.start)
+            return "<\(cue.start - lineStart),\(max(0, end - cue.start))>\(values[index])"
+        }.joined()
+        return "[\(lineStart),\(max(0, lineEnd - lineStart))]\(body)"
+    }
+
+    /// byteStart/byteEnd point into cueLine.value's final UTF-8 bytes. Taking
+    /// each segment up to the next cue retains spaces and any untimed text.
+    private static func resolvedValues(
+        for cues: [TimedCue],
+        canonicalLine: String?
+    ) -> [String] {
+        let fallback = cues.map { oneLine($0.value) }
+        guard let canonicalLine, !canonicalLine.isEmpty else { return fallback }
+        let bytes = Array(canonicalLine.utf8)
+        var result: [String] = []
+        for index in cues.indices {
+            guard let start = cues[index].byteStart,
+                  let end = cues[index].byteEnd,
+                  start >= 0, end >= start, end < bytes.count else {
+                return fallback
+            }
+            let lower = index == cues.startIndex ? 0 : start
+            let upper: Int
+            if cues.indices.contains(index + 1) {
+                guard let nextStart = cues[index + 1].byteStart,
+                      nextStart > end, nextStart <= bytes.count else { return fallback }
+                upper = nextStart
+            } else {
+                upper = bytes.count
+            }
+            guard lower < upper,
+                  let value = String(bytes: bytes[lower..<upper], encoding: .utf8) else {
+                return fallback
+            }
+            result.append(oneLine(value))
+        }
+        return result
+    }
+
+    private static func normalizedKind(_ value: String?) -> String {
+        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return normalized.isEmpty ? "main" : normalized.lowercased()
+    }
+
+    private static func lineValue(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = oneLine(value)
+        return normalized.trimmingCharacters(in: .whitespaces).isEmpty ? nil : normalized
+    }
+
+    private static func oneLine(_ value: String) -> String {
+        value.replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+    }
+
+    private static func lrcTimestamp(_ milliseconds: Int) -> String {
+        let centiseconds = max(0, milliseconds) / 10
+        return String(
+            format: "[%02d:%02d.%02d]",
+            centiseconds / 6_000,
+            (centiseconds / 100) % 60,
+            centiseconds % 100
+        )
+    }
+
+    /// OpenSubsonic defines a positive track offset as displaying lyrics
+    /// earlier, and a negative offset as displaying them later.
+    private static func adjustedTimestamp(_ timestamp: Int, offset: Int) -> Int {
+        let nonnegativeTimestamp = max(0, timestamp)
+        if offset >= 0 {
+            return offset >= nonnegativeTimestamp ? 0 : nonnegativeTimestamp - offset
+        }
+        guard offset != .min else { return .max }
+        let (adjusted, overflow) = nonnegativeTimestamp.addingReportingOverflow(-offset)
+        return overflow ? .max : adjusted
+    }
+
+    private static func addingMilliseconds(_ milliseconds: Int, to timestamp: Int) -> Int {
+        let (result, overflow) = timestamp.addingReportingOverflow(milliseconds)
+        return overflow ? .max : result
+    }
+
+    private struct TimedCue {
+        let order: Int
+        let start: Int
+        let end: Int?
+        let value: String
+        let byteStart: Int?
+        let byteEnd: Int?
+    }
+}

--- a/PrimuseKit/Tests/PrimuseKitTests/OpenSubsonicLyricsTests.swift
+++ b/PrimuseKit/Tests/PrimuseKitTests/OpenSubsonicLyricsTests.swift
@@ -1,0 +1,274 @@
+import Foundation
+import Testing
+@testable import PrimuseKit
+
+@Suite("OpenSubsonic enhanced lyrics")
+struct OpenSubsonicLyricsTests {
+    @Test("Prefers the main track and preserves cue start and end times")
+    func convertsVersionTwoCueLines() throws {
+        let tracks = try decodeTracks(#"""
+        [
+          {
+            "kind": "translation",
+            "synced": true,
+            "line": [{"start": 900, "value": "Translated line"}]
+          },
+          {
+            "kind": "main",
+            "synced": true,
+            "line": [
+              {"start": 900, "value": "I sing"},
+              {"start": 3000, "value": "Next line"}
+            ],
+            "cueLine": [
+              {
+                "index": 0,
+                "start": 900,
+                "end": 2000,
+                "value": "I sing",
+                "cue": [
+                  {"start": 1000, "end": 1350, "value": "I", "byteStart": 0, "byteEnd": 0},
+                  {"start": 1500, "end": 2000, "value": "sing", "byteStart": 2, "byteEnd": 5}
+                ]
+              }
+            ]
+          }
+        ]
+        """#)
+
+        let text = try #require(OpenSubsonicLyricsConverter.text(from: tracks))
+        let lines = LyricsContentParser.parseText(text)
+
+        #expect(lines.count == 2)
+        #expect(lines[0].text == "I sing")
+        #expect(lines[0].timestamp == 0.9)
+        let syllables = try #require(lines[0].syllables)
+        #expect(syllables.count == 2)
+        #expect(syllables[0] == LyricSyllable(text: "I ", start: 1.0, end: 1.35))
+        #expect(syllables[1] == LyricSyllable(text: "sing", start: 1.5, end: 2.0))
+        #expect(lines[1].text == "Next line")
+        #expect(lines[1].timestamp == 3.0)
+        #expect(lines[1].syllables == nil)
+    }
+
+    @Test("Prefers the cue-capable main track when a server returns duplicate mains")
+    func prefersCueCapableMainTrack() throws {
+        let tracks = try decodeTracks(#"""
+        [
+          {
+            "kind": "main",
+            "synced": true,
+            "line": [{"start": 1000, "value": "Line-only copy"}]
+          },
+          {
+            "kind": "main",
+            "synced": true,
+            "line": [{"start": 2000, "value": "Word timed"}],
+            "cueLine": [
+              {
+                "index": 0,
+                "start": 2000,
+                "end": 3000,
+                "value": "Word timed",
+                "cue": [
+                  {"start": 2000, "end": 2400, "value": "Word "},
+                  {"start": 2500, "end": 3000, "value": "timed"}
+                ]
+              }
+            ]
+          }
+        ]
+        """#)
+
+        let text = try #require(OpenSubsonicLyricsConverter.text(from: tracks))
+        let line = try #require(LyricsContentParser.parseText(text).first)
+
+        #expect(line.text == "Word timed")
+        #expect(line.syllables?.count == 2)
+    }
+
+    @Test("Infers cue ends when a server returns start-only enhanced LRC data")
+    func infersMissingCueEnds() throws {
+        let tracks = try decodeTracks(#"""
+        [
+          {
+            "kind": "main",
+            "synced": true,
+            "line": [{"start": 5000, "value": "la la"}],
+            "cueLine": [
+              {
+                "index": 0,
+                "start": 5000,
+                "end": 6200,
+                "cue": [
+                  {"start": 5100, "value": "la "},
+                  {"start": 5600, "value": "la"}
+                ]
+              }
+            ]
+          }
+        ]
+        """#)
+
+        let text = try #require(OpenSubsonicLyricsConverter.text(from: tracks))
+        let line = try #require(LyricsContentParser.parseText(text).first)
+        let syllables = try #require(line.syllables)
+
+        #expect(syllables[0] == LyricSyllable(text: "la ", start: 5.1, end: 5.6))
+        #expect(syllables[1] == LyricSyllable(text: "la", start: 5.6, end: 6.2))
+    }
+
+    @Test("Uses UTF-8 byte offsets to retain spaces and untimed text")
+    func retainsCanonicalCueLineText() throws {
+        let tracks = try decodeTracks(#"""
+        [
+          {
+            "kind": "main",
+            "synced": true,
+            "line": [{"start": 0, "value": "Oh love love me tonight"}],
+            "cueLine": [
+              {
+                "index": 0,
+                "start": 0,
+                "end": 2400,
+                "value": "Oh love love me tonight",
+                "cue": [
+                  {"start": 0, "end": 300, "value": "Oh", "byteStart": 0, "byteEnd": 1},
+                  {"start": 900, "end": 1300, "value": "love", "byteStart": 8, "byteEnd": 11},
+                  {"start": 1300, "end": 1600, "value": "me", "byteStart": 13, "byteEnd": 14},
+                  {"start": 1600, "end": 2400, "value": "tonight", "byteStart": 16, "byteEnd": 22}
+                ]
+              }
+            ]
+          }
+        ]
+        """#)
+
+        let text = try #require(OpenSubsonicLyricsConverter.text(from: tracks))
+        let line = try #require(LyricsContentParser.parseText(text).first)
+        let syllables = try #require(line.syllables)
+
+        #expect(line.text == "Oh love love me tonight")
+        #expect(syllables.map(\.text) == ["Oh love ", "love ", "me ", "tonight"])
+    }
+
+    @Test("Keeps version one line lyrics as a backward-compatible fallback")
+    func keepsVersionOneLyrics() throws {
+        let tracks = try decodeTracks(#"""
+        [
+          {
+            "synced": true,
+            "offset": -100,
+            "line": [
+              {"start": 1250, "value": "Line one"},
+              {"start": 2500, "value": "Line two"}
+            ]
+          }
+        ]
+        """#)
+
+        let text = try #require(OpenSubsonicLyricsConverter.text(from: tracks))
+        let lines = LyricsContentParser.parseText(text)
+
+        #expect(lines.map(\.text) == ["Line one", "Line two"])
+        #expect(lines.map(\.timestamp) == [1.35, 2.6])
+        #expect(lines.allSatisfy { $0.syllables == nil })
+    }
+
+    @Test("Applies the track offset to line and cue timing")
+    func appliesTrackOffset() throws {
+        let tracks = try decodeTracks(#"""
+        [
+          {
+            "kind": "main",
+            "synced": true,
+            "offset": 250,
+            "line": [{"start": 1000, "value": "Shift me"}],
+            "cueLine": [
+              {
+                "index": 0,
+                "start": 1000,
+                "end": 2000,
+                "cue": [
+                  {"start": 1100, "end": 1400, "value": "Shift "},
+                  {"start": 1500, "end": 2000, "value": "me"}
+                ]
+              }
+            ]
+          }
+        ]
+        """#)
+
+        let text = try #require(OpenSubsonicLyricsConverter.text(from: tracks))
+        let line = try #require(LyricsContentParser.parseText(text).first)
+        let syllables = try #require(line.syllables)
+
+        #expect(line.timestamp == 0.75)
+        #expect(syllables[0] == LyricSyllable(text: "Shift ", start: 0.85, end: 1.15))
+        #expect(syllables[1] == LyricSyllable(text: "me", start: 1.25, end: 1.75))
+    }
+
+    @Test("Preserves an explicitly instantaneous cue")
+    func preservesZeroDurationCue() throws {
+        let tracks = try decodeTracks(#"""
+        [
+          {
+            "kind": "main",
+            "synced": true,
+            "line": [{"start": 1000, "value": "Now"}],
+            "cueLine": [
+              {
+                "index": 0,
+                "start": 1000,
+                "end": 1500,
+                "cue": [{"start": 1100, "end": 1100, "value": "Now"}]
+              }
+            ]
+          }
+        ]
+        """#)
+
+        let text = try #require(OpenSubsonicLyricsConverter.text(from: tracks))
+        let syllable = try #require(LyricsContentParser.parseText(text).first?.syllables?.first)
+
+        #expect(syllable.start == 1.1)
+        #expect(syllable.end == 1.1)
+    }
+
+    @Test("Uses the first cue line as the lead layer for parallel vocal agents")
+    func keepsLeadCueLine() throws {
+        let tracks = try decodeTracks(#"""
+        [
+          {
+            "kind": "main",
+            "synced": true,
+            "line": [{"start": 1000, "value": "Lead backing"}],
+            "cueLine": [
+              {
+                "index": 0,
+                "start": 1000,
+                "end": 1800,
+                "cue": [{"start": 1000, "end": 1800, "value": "Lead"}]
+              },
+              {
+                "index": 0,
+                "start": 1200,
+                "end": 1800,
+                "cue": [{"start": 1200, "end": 1800, "value": "backing"}]
+              }
+            ]
+          }
+        ]
+        """#)
+
+        let text = try #require(OpenSubsonicLyricsConverter.text(from: tracks))
+        let line = try #require(LyricsContentParser.parseText(text).first)
+
+        #expect(line.text == "Lead")
+        #expect(line.syllables?.count == 1)
+    }
+
+    private func decodeTracks(_ json: String) throws -> [OpenSubsonicLyricsConverter.Track] {
+        try JSONDecoder().decode([OpenSubsonicLyricsConverter.Track].self, from: Data(json.utf8))
+    }
+}


### PR DESCRIPTION
## Summary

- Request `getLyricsBySongId` with `enhanced=true`, with a retry of the original request when a server rejects the optional parameter.
- Decode OpenSubsonic songLyrics v2 cue timing and convert it to the relative A2-LRC representation already supported by Primuse.
- Preserve v1 line-lyrics fallback, track offsets, UTF-8 byte ranges and untimed text, start-only cue inference, and zero-duration cues.
- Prefer cue-capable main tracks and render the protocol-ordered main/lead cue line when parallel vocal agents share a line.

## Why

Primuse currently requests the default songLyrics v1 response, so Navidrome/OpenSubsonic word timing from TTML or Enhanced LRC is flattened to line-level lyrics before it reaches the karaoke UI.

## Compatibility

- The legacy Airsonic `getLyrics` path is unchanged.
- Servers that ignore `enhanced` continue returning v1 data.
- Servers that reject it are retried without the parameter.
- Translation and pronunciation tracks are not substituted for primary lyrics.
- The current single-document connector keeps the lead layer renderable instead of interleaving parallel background vocals.

## Validation

- Added eight focused converter/parser tests covering v2 and v1 responses, duplicate main tracks, missing cue ends, UTF-8 offsets, track offsets, zero-duration cues, and layered agents.
- `swift build --package-path PrimuseKit` passes.
- The converter type-checks with warnings treated as errors.
- A full-module regression harness passes, including the production GRDB dependency context.
- The Swift Testing suite could not run on this CommandLineTools-only host because the `Testing` module is unavailable.