### PR TITLE
fix(ios): 加载首页电台网格的服务器封面

### DIFF
--- a/Primuse/Views/Home/HomeView.swift
+++ b/Primuse/Views/Home/HomeView.swift
@@ -912,7 +912,21 @@ struct HomeView: View {
                 .resizable()
                 .scaledToFill()
         } else {
-            RadioStationPlaceholderArtwork()
+            ZStack {
+                RadioStationPlaceholderArtwork()
+                if station.logoFileName?.isEmpty == false {
+                    CachedArtworkView(
+                        coverRef: station.logoFileName,
+                        songID: station.playbackSong.id,
+                        cornerRadius: 0,
+                        sourceID: station.sourceID,
+                        filePath: station.sourcePlaybackPath ?? station.streamURL,
+                        fileFormat: station.streamFormat.audioFormat,
+                        placeholderIcon: "radio.fill",
+                        showsPlaceholder: false
+                    )
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## 问题

#51 已经把 Navidrome / OpenSubsonic 返回的电台 `coverArt` 引用保存到 `RadioStation.logoFileName`。但 iOS 首页“我的电台”网格中的 `radioWallArtwork` 只读取内嵌的 `logoData`，否则直接显示默认占位图。

因此，同一个电台会出现：
- 首页顶部焦点卡片可以显示服务器封面；
- 完整电台页可以显示服务器封面；
- 首页“我的电台”网格仍显示默认封面。

## 修改

- 保留内嵌 `logoData` 的优先级；
- 当 `logoData` 不存在但 `logoFileName` 有值时，使用现有 `CachedArtworkView` 加载服务器封面；
- 继续传入来源、播放路径和格式信息，以复用已有的认证封面解析流程；
- 加载失败或服务端没有封面时，仍保留现有电台占位图。

## 验证

- `xcrun swiftc -frontend -parse Primuse/Views/Home/HomeView.swift`
- `swift build --package-path PrimuseKit`
- `git diff --check`

当前机器只有 Command Line Tools，没有完整 Xcode，因此无法执行 iOS `xcodebuild`。`swift test --package-path PrimuseKit` 可完成库源码编译，但测试目标因当前命令行工具环境缺少 `Testing` 模块而无法编译。

这是 #51 的后续修复。