### PR TITLE
支持 iPhone 向附近设备发送音频缓存

### DIFF
--- a/Primuse/Resources/de.lproj/CacheSync.strings
+++ b/Primuse/Resources/de.lproj/CacheSync.strings
@@ -2,7 +2,7 @@
 "cache_sync_subtitle" = "Vorhandenen Audio-Cache direkt an ein anderes Primuse-Gerät senden";
 "cache_sync_refresh" = "Erneut suchen";
 "cache_sync_close" = "Schließen";
-"cache_sync_local_cache" = "Auf diesem Mac verfügbarer Cache";
+"cache_sync_local_cache" = "Auf diesem Gerät verfügbarer Cache";
 "cache_sync_inventory_format" = "%d Cache-Dateien · %@";
 "cache_sync_preparing_inventory" = "Vollständige Cache-Dateien werden geprüft…";
 "cache_sync_receiver_ready" = "Sichtbar";
@@ -30,3 +30,15 @@
 "cache_sync_error_discovery" = "Gerätesuche fehlgeschlagen. Berechtigung für das lokale Netzwerk prüfen.";
 "cache_sync_error_connection" = "Caches konnten nicht verglichen werden. Primuse auf beiden Geräten geöffnet lassen.";
 "cache_sync_error_transfer" = "Synchronisierung unterbrochen. Bereits geprüfte Dateien bleiben erhalten.";
+"cache_sync_local_device" = "Dieses Gerät";
+"cache_sync_device_status" = "Gerätestatus";
+"cache_sync_local_network_footer" = "Cache-Dateien werden direkt über das lokale Netzwerk gesendet. Primuse lädt sie nicht erneut vom Medienserver herunter.";
+"cache_sync_missing_on_target" = "Auf dem Zielgerät fehlend";
+"cache_sync_test_three" = "Mit bis zu 3 Dateien testen";
+"cache_sync_sync_all" = "Alle fehlenden synchronisieren";
+"cache_sync_test_three_footer" = "Zuerst bis zu drei fehlende Dateien übertragen, um die Verbindung zu prüfen, danach den Rest synchronisieren.";
+"cache_sync_keep_foreground" = "Primuse auf diesem Bildschirm geöffnet lassen und beide Geräte bis zum Abschluss aktiv halten.";
+"cache_sync_retry" = "Erneut versuchen";
+"cache_sync_confirm_all_title" = "Alle fehlenden Cache-Dateien synchronisieren?";
+"cache_sync_confirm_all_message_format" = "%d fehlende Dateien (%@) direkt an das ausgewählte Gerät senden.";
+"cache_sync_test_transferred_titles" = "In diesem Test übertragene Dateien";

--- a/Primuse/Resources/en.lproj/CacheSync.strings
+++ b/Primuse/Resources/en.lproj/CacheSync.strings
@@ -2,7 +2,7 @@
 "cache_sync_subtitle" = "Send existing audio cache directly to another Primuse device";
 "cache_sync_refresh" = "Detect Again";
 "cache_sync_close" = "Close";
-"cache_sync_local_cache" = "Cache available on this Mac";
+"cache_sync_local_cache" = "Cache available on this device";
 "cache_sync_inventory_format" = "%d cached files · %@";
 "cache_sync_preparing_inventory" = "Checking complete cache files…";
 "cache_sync_receiver_ready" = "Discoverable";
@@ -30,3 +30,15 @@
 "cache_sync_error_discovery" = "Nearby-device detection failed. Check Local Network permission and try again.";
 "cache_sync_error_connection" = "Could not compare caches with this device. Keep Primuse open on both devices and try again.";
 "cache_sync_error_transfer" = "Cache sync was interrupted. Files already verified on the target device are preserved.";
+"cache_sync_local_device" = "This Device";
+"cache_sync_device_status" = "Device Status";
+"cache_sync_local_network_footer" = "Cache files are sent directly over the local network. Primuse does not download them again from the media server.";
+"cache_sync_missing_on_target" = "Missing on Target";
+"cache_sync_test_three" = "Test with Up to 3 Files";
+"cache_sync_sync_all" = "Sync All Missing";
+"cache_sync_test_three_footer" = "Start with up to three missing files to verify the connection, then sync the rest.";
+"cache_sync_keep_foreground" = "Keep Primuse open on this screen and keep both devices awake until the transfer finishes.";
+"cache_sync_retry" = "Try Again";
+"cache_sync_confirm_all_title" = "Sync all missing cache?";
+"cache_sync_confirm_all_message_format" = "Send %d missing files (%@) directly to the selected device.";
+"cache_sync_test_transferred_titles" = "Files transferred in this test";

--- a/Primuse/Resources/fr.lproj/CacheSync.strings
+++ b/Primuse/Resources/fr.lproj/CacheSync.strings
@@ -2,7 +2,7 @@
 "cache_sync_subtitle" = "Envoyer le cache audio existant directement vers un autre appareil Primuse";
 "cache_sync_refresh" = "Détecter à nouveau";
 "cache_sync_close" = "Fermer";
-"cache_sync_local_cache" = "Cache disponible sur ce Mac";
+"cache_sync_local_cache" = "Cache disponible sur cet appareil";
 "cache_sync_inventory_format" = "%d fichiers en cache · %@";
 "cache_sync_preparing_inventory" = "Vérification des fichiers complets…";
 "cache_sync_receiver_ready" = "Détectable";
@@ -30,3 +30,15 @@
 "cache_sync_error_discovery" = "Échec de la détection. Vérifiez l’autorisation Réseau local.";
 "cache_sync_error_connection" = "Impossible de comparer les caches. Gardez Primuse ouvert sur les deux appareils.";
 "cache_sync_error_transfer" = "Synchronisation interrompue. Les fichiers déjà vérifiés sont conservés.";
+"cache_sync_local_device" = "Cet appareil";
+"cache_sync_device_status" = "État de l’appareil";
+"cache_sync_local_network_footer" = "Les fichiers en cache sont envoyés directement sur le réseau local. Primuse ne les retélécharge pas depuis le serveur multimédia.";
+"cache_sync_missing_on_target" = "Manquant sur la cible";
+"cache_sync_test_three" = "Tester avec 3 fichiers maximum";
+"cache_sync_sync_all" = "Tout synchroniser";
+"cache_sync_test_three_footer" = "Commencez par trois fichiers manquants maximum pour vérifier la connexion, puis synchronisez le reste.";
+"cache_sync_keep_foreground" = "Gardez Primuse ouvert sur cet écran et les deux appareils actifs jusqu’à la fin du transfert.";
+"cache_sync_retry" = "Réessayer";
+"cache_sync_confirm_all_title" = "Synchroniser tout le cache manquant ?";
+"cache_sync_confirm_all_message_format" = "Envoyer directement %d fichiers manquants (%@) vers l’appareil sélectionné.";
+"cache_sync_test_transferred_titles" = "Fichiers transférés pendant ce test";

--- a/Primuse/Resources/ja.lproj/CacheSync.strings
+++ b/Primuse/Resources/ja.lproj/CacheSync.strings
@@ -2,7 +2,7 @@
 "cache_sync_subtitle" = "既存の音声キャッシュを別の Primuse デバイスへ直接送信します";
 "cache_sync_refresh" = "もう一度検出";
 "cache_sync_close" = "閉じる";
-"cache_sync_local_cache" = "この Mac で利用可能なキャッシュ";
+"cache_sync_local_cache" = "このデバイスで利用可能なキャッシュ";
 "cache_sync_inventory_format" = "%d 個のキャッシュファイル · %@";
 "cache_sync_preparing_inventory" = "完全なキャッシュファイルを確認しています…";
 "cache_sync_receiver_ready" = "検出可能";
@@ -30,3 +30,15 @@
 "cache_sync_error_discovery" = "近くのデバイスを検出できませんでした。ローカルネットワークの権限を確認して、もう一度お試しください。";
 "cache_sync_error_connection" = "このデバイスとキャッシュを比較できませんでした。両方のデバイスで Primuse を開いたまま、もう一度お試しください。";
 "cache_sync_error_transfer" = "キャッシュ同期が中断されました。送信先で確認済みのファイルは保持されています。";
+"cache_sync_local_device" = "このデバイス";
+"cache_sync_device_status" = "デバイスの状態";
+"cache_sync_local_network_footer" = "キャッシュファイルはローカルネットワーク経由で直接送信されます。Primuse がメディアサーバーから再ダウンロードすることはありません。";
+"cache_sync_missing_on_target" = "送信先で不足";
+"cache_sync_test_three" = "最大 3 ファイルでテスト";
+"cache_sync_sync_all" = "不足分をすべて同期";
+"cache_sync_test_three_footer" = "最初に不足ファイルを最大 3 件送信して接続を確認し、その後に残りを同期してください。";
+"cache_sync_keep_foreground" = "転送が完了するまで Primuse をこの画面で開き、両方のデバイスをスリープさせないでください。";
+"cache_sync_retry" = "再試行";
+"cache_sync_confirm_all_title" = "不足しているキャッシュをすべて同期しますか？";
+"cache_sync_confirm_all_message_format" = "不足している %d ファイル（%@）を選択したデバイスへ直接送信します。";
+"cache_sync_test_transferred_titles" = "今回のテストで転送したファイル";

--- a/Primuse/Resources/ko.lproj/CacheSync.strings
+++ b/Primuse/Resources/ko.lproj/CacheSync.strings
@@ -2,7 +2,7 @@
 "cache_sync_subtitle" = "기존 오디오 캐시를 다른 Primuse 기기로 직접 전송";
 "cache_sync_refresh" = "다시 감지";
 "cache_sync_close" = "닫기";
-"cache_sync_local_cache" = "이 Mac에서 전송 가능한 캐시";
+"cache_sync_local_cache" = "이 기기에서 전송 가능한 캐시";
 "cache_sync_inventory_format" = "캐시 파일 %d개 · %@";
 "cache_sync_preparing_inventory" = "완전한 캐시 파일 확인 중…";
 "cache_sync_receiver_ready" = "검색 가능";
@@ -30,3 +30,15 @@
 "cache_sync_error_discovery" = "근처 기기 감지에 실패했습니다. 로컬 네트워크 권한을 확인하세요.";
 "cache_sync_error_connection" = "캐시를 비교할 수 없습니다. 두 기기에서 Primuse를 열어 두세요.";
 "cache_sync_error_transfer" = "캐시 동기화가 중단되었습니다. 검증된 파일은 대상 기기에 유지됩니다.";
+"cache_sync_local_device" = "이 기기";
+"cache_sync_device_status" = "기기 상태";
+"cache_sync_local_network_footer" = "캐시 파일은 로컬 네트워크를 통해 직접 전송됩니다. Primuse가 미디어 서버에서 다시 다운로드하지 않습니다.";
+"cache_sync_missing_on_target" = "대상 기기에 없음";
+"cache_sync_test_three" = "최대 3개 파일로 테스트";
+"cache_sync_sync_all" = "누락된 캐시 모두 동기화";
+"cache_sync_test_three_footer" = "먼저 누락된 파일을 최대 3개 전송해 연결을 확인한 다음 나머지를 동기화하세요.";
+"cache_sync_keep_foreground" = "전송이 끝날 때까지 Primuse를 이 화면에 열어 두고 두 기기를 깨운 상태로 유지하세요.";
+"cache_sync_retry" = "다시 시도";
+"cache_sync_confirm_all_title" = "누락된 캐시를 모두 동기화할까요?";
+"cache_sync_confirm_all_message_format" = "누락된 파일 %d개(%@)를 선택한 기기로 직접 전송합니다.";
+"cache_sync_test_transferred_titles" = "이번 테스트에서 전송된 파일";

--- a/Primuse/Resources/zh-Hans.lproj/CacheSync.strings
+++ b/Primuse/Resources/zh-Hans.lproj/CacheSync.strings
@@ -2,7 +2,7 @@
 "cache_sync_subtitle" = "将已有音频缓存直接发送到另一台 Primuse 设备";
 "cache_sync_refresh" = "重新检测";
 "cache_sync_close" = "关闭";
-"cache_sync_local_cache" = "这台 Mac 可同步的缓存";
+"cache_sync_local_cache" = "这台设备可同步的缓存";
 "cache_sync_inventory_format" = "%d 个缓存文件 · %@";
 "cache_sync_preparing_inventory" = "正在检查完整缓存文件…";
 "cache_sync_receiver_ready" = "可被发现";
@@ -30,3 +30,15 @@
 "cache_sync_error_discovery" = "附近设备检测失败，请检查“本地网络”权限后重试。";
 "cache_sync_error_connection" = "无法与这台设备比较缓存，请让两端 Primuse 保持打开后重试。";
 "cache_sync_error_transfer" = "缓存同步已中断；目标设备上已经校验完成的文件会保留。";
+"cache_sync_local_device" = "本机";
+"cache_sync_device_status" = "设备状态";
+"cache_sync_local_network_footer" = "缓存文件仅通过局域网直传；同步过程不会从媒体服务器重新下载音频。";
+"cache_sync_missing_on_target" = "目标设备缺少";
+"cache_sync_test_three" = "先试传最多 3 个文件";
+"cache_sync_sync_all" = "同步全部缺失缓存";
+"cache_sync_test_three_footer" = "建议先试传最多 3 个缺失文件，确认连接正常后再同步其余缓存。";
+"cache_sync_keep_foreground" = "传输完成前，请让两台设备保持唤醒，并让 Primuse 停留在此页面。";
+"cache_sync_retry" = "重试";
+"cache_sync_confirm_all_title" = "同步全部缺失缓存？";
+"cache_sync_confirm_all_message_format" = "将 %d 个缺失文件（%@）直接发送到所选设备。";
+"cache_sync_test_transferred_titles" = "本次试传的文件";

--- a/Primuse/Resources/zh-Hant.lproj/CacheSync.strings
+++ b/Primuse/Resources/zh-Hant.lproj/CacheSync.strings
@@ -2,7 +2,7 @@
 "cache_sync_subtitle" = "將現有音訊快取直接傳送到另一台 Primuse 裝置";
 "cache_sync_refresh" = "重新偵測";
 "cache_sync_close" = "關閉";
-"cache_sync_local_cache" = "這台 Mac 可同步的快取";
+"cache_sync_local_cache" = "這台裝置可同步的快取";
 "cache_sync_inventory_format" = "%d 個快取檔案 · %@";
 "cache_sync_preparing_inventory" = "正在檢查完整快取檔案…";
 "cache_sync_receiver_ready" = "可被偵測";
@@ -30,3 +30,15 @@
 "cache_sync_error_discovery" = "附近裝置偵測失敗，請檢查「本機網路」權限後重試。";
 "cache_sync_error_connection" = "無法與這台裝置比較快取，請讓兩端 Primuse 保持開啟後重試。";
 "cache_sync_error_transfer" = "快取同步已中斷；目標裝置上已完成驗證的檔案會保留。";
+"cache_sync_local_device" = "本機";
+"cache_sync_device_status" = "裝置狀態";
+"cache_sync_local_network_footer" = "快取檔案只會透過區域網路直接傳送；同步過程不會從媒體伺服器重新下載音訊。";
+"cache_sync_missing_on_target" = "目標裝置缺少";
+"cache_sync_test_three" = "先試傳最多 3 個檔案";
+"cache_sync_sync_all" = "同步所有缺少的快取";
+"cache_sync_test_three_footer" = "建議先試傳最多 3 個缺少的檔案，確認連線正常後再同步其餘快取。";
+"cache_sync_keep_foreground" = "傳輸完成前，請讓兩台裝置保持喚醒，並讓 Primuse 停留在此頁面。";
+"cache_sync_retry" = "重試";
+"cache_sync_confirm_all_title" = "同步所有缺少的快取？";
+"cache_sync_confirm_all_message_format" = "將 %d 個缺少的檔案（%@）直接傳送到所選裝置。";
+"cache_sync_test_transferred_titles" = "本次試傳的檔案";

--- a/Primuse/Services/Audio/AudioCacheSyncService.swift
+++ b/Primuse/Services/Audio/AudioCacheSyncService.swift
@@ -75,6 +75,7 @@ struct AudioCacheSyncTransferCompletion: Equatable, Sendable {
     let transferredFileCount: Int
     let failedFileCount: Int
     let transferredByteCount: Int64
+    let transferredTitles: [String]
 }
 
 enum AudioCacheSyncOperation: Equatable, Sendable {
@@ -122,6 +123,15 @@ enum AudioCacheSyncPolicy {
         let maximumResult = catalogByteCount.addingReportingOverflow(4 * 1_024)
         let maximum = maximumResult.overflow ? Int64.max : maximumResult.partialValue
         return transferredByteCount >= minimum && transferredByteCount <= maximum
+    }
+
+    static func limitedItemIDs(
+        _ itemIDs: [String],
+        maximumCount: Int?
+    ) -> [String] {
+        guard let maximumCount else { return itemIDs }
+        guard maximumCount > 0 else { return [] }
+        return Array(itemIDs.prefix(maximumCount))
     }
 }
 
@@ -413,7 +423,7 @@ final class AudioCacheSyncService {
         }
     }
 
-    func sync(to peerID: String) {
+    func sync(to peerID: String, maximumFileCount: Int? = nil) {
         guard operation == .idle,
               let endpoint = endpointByPeerID[peerID],
               let publicKey = publicKeyByPeerID[peerID] else { return }
@@ -427,10 +437,26 @@ final class AudioCacheSyncService {
         transferProgress = nil
         operationTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            let manifest = await self.buildLocalManifest()
+            let fullManifest = await self.buildLocalManifest()
             guard !Task.isCancelled, self.activeOperationID == operationID else { return }
-            self.localInventory = manifest.summary
+            self.localInventory = fullManifest.summary
             do {
+                let manifest: AudioCacheSyncLocalManifest
+                if maximumFileCount != nil {
+                    let currentPlan = try await Self.requestPlan(
+                        endpoint: endpoint,
+                        receiverPublicKey: publicKey,
+                        manifest: fullManifest,
+                        action: .inspect
+                    )
+                    manifest = Self.transferManifest(
+                        fullManifest,
+                        missingItemIDs: currentPlan.missingItemIDs,
+                        maximumFileCount: maximumFileCount
+                    )
+                } else {
+                    manifest = fullManifest
+                }
                 let outcome = try await Self.transfer(
                     endpoint: endpoint,
                     receiverPublicKey: publicKey,
@@ -444,18 +470,37 @@ final class AudioCacheSyncService {
                     )
                 }
                 guard !Task.isCancelled, self.activeOperationID == operationID else { return }
-                self.peerPlans[peerID] = AudioCacheSyncPeerPlan(
-                    peerID: peerID,
-                    missingFileCount: outcome.plan.missingFileCount,
-                    missingByteCount: outcome.plan.missingByteCount,
-                    alreadyPresentCount: outcome.plan.alreadyPresentCount,
-                    rejectedCount: outcome.plan.rejectedCount
-                )
+                if maximumFileCount != nil,
+                   let refreshedWirePlan = try? await Self.requestPlan(
+                       endpoint: endpoint,
+                       receiverPublicKey: publicKey,
+                       manifest: fullManifest,
+                       action: .inspect
+                   ) {
+                    self.peerPlans[peerID] = Self.peerPlan(
+                        peerID: peerID,
+                        wirePlan: refreshedWirePlan,
+                        manifest: fullManifest
+                    )
+                } else {
+                    self.peerPlans[peerID] = AudioCacheSyncPeerPlan(
+                        peerID: peerID,
+                        missingFileCount: outcome.plan.missingFileCount,
+                        missingByteCount: outcome.plan.missingByteCount,
+                        alreadyPresentCount: outcome.plan.alreadyPresentCount,
+                        rejectedCount: outcome.plan.rejectedCount
+                    )
+                }
                 self.lastCompletion = AudioCacheSyncTransferCompletion(
                     peerID: peerID,
                     transferredFileCount: outcome.summary.transferredFileCount,
                     failedFileCount: outcome.summary.failedFileCount,
-                    transferredByteCount: outcome.summary.transferredByteCount
+                    transferredByteCount: outcome.summary.transferredByteCount,
+                    transferredTitles: maximumFileCount == nil
+                        ? []
+                        : outcome.transferredItemIDs.compactMap {
+                            manifest.filesByID[$0]?.title
+                        }
                 )
                 self.transferProgress = nil
                 self.operation = .idle
@@ -896,6 +941,21 @@ final class AudioCacheSyncService {
         )
     }
 
+    private static func transferManifest(
+        _ manifest: AudioCacheSyncLocalManifest,
+        missingItemIDs: [String],
+        maximumFileCount: Int?
+    ) -> AudioCacheSyncLocalManifest {
+        let selectedIDs = AudioCacheSyncPolicy.limitedItemIDs(
+            missingItemIDs,
+            maximumCount: maximumFileCount
+        )
+        let filesByID = manifest.filesByID
+        return AudioCacheSyncLocalManifest(
+            files: selectedIDs.compactMap { filesByID[$0] }
+        )
+    }
+
     private static func requestPlan(
         endpoint: NWEndpoint,
         receiverPublicKey: Data,
@@ -925,7 +985,11 @@ final class AudioCacheSyncService {
         receiverPublicKey: Data,
         manifest: AudioCacheSyncLocalManifest,
         progress: @escaping @Sendable (AudioCacheSyncNetworkProgress) async -> Void
-    ) async throws -> (plan: AudioCacheSyncPeerPlan, summary: AudioCacheSyncWireTransferSummary) {
+    ) async throws -> (
+        plan: AudioCacheSyncPeerPlan,
+        summary: AudioCacheSyncWireTransferSummary,
+        transferredItemIDs: [String]
+    ) {
         let socket = AudioCacheSyncSocket(connection: NWConnection(to: endpoint, using: .tcp))
         return try await withTaskCancellationHandler {
             defer { socket.cancel() }
@@ -947,6 +1011,7 @@ final class AudioCacheSyncService {
             var completed = 0
             var failed = 0
             var sentBytes: Int64 = 0
+            var transferredItemIDs: [String] = []
 
             await progress(AudioCacheSyncNetworkProgress(
                 completedFileCount: 0,
@@ -1053,6 +1118,7 @@ final class AudioCacheSyncService {
                     let result = try await session.receiveJSON(AudioCacheSyncWireFileResult.self)
                     if result.itemID == itemID, result.succeeded {
                         completed += 1
+                        transferredItemIDs.append(itemID)
                     } else {
                         failed += 1
                     }
@@ -1081,7 +1147,7 @@ final class AudioCacheSyncService {
                 alreadyPresentCount: wirePlan.alreadyPresentCount + summary.transferredFileCount,
                 rejectedCount: wirePlan.rejectedCount
             )
-            return (finalizedPlan, summary)
+            return (finalizedPlan, summary, transferredItemIDs)
         } onCancel: {
             socket.cancel()
         }

--- a/Primuse/Views/Settings/SettingsView.swift
+++ b/Primuse/Views/Settings/SettingsView.swift
@@ -142,6 +142,18 @@ struct SettingsView: View {
                 }
 
                 Section("sync") {
+                    #if os(iOS)
+                    NavigationLink {
+                        IOSAudioCacheSyncView()
+                    } label: {
+                        Label {
+                            Text(verbatim: CacheSyncLocalization.text("cache_sync_title"))
+                        } icon: {
+                            Image(systemName: "arrow.left.arrow.right.circle")
+                        }
+                    }
+                    #endif
+
                     NavigationLink {
                         CloudSyncSettingsView()
                     } label: {
@@ -279,6 +291,461 @@ struct SettingsView: View {
 }
 
 #if os(iOS)
+private struct IOSAudioCacheSyncView: View {
+    @Environment(AudioCacheSyncService.self) private var cacheSync
+    @State private var selectedPeerID: String?
+    @State private var showsFullSyncConfirmation = false
+    @State private var previousIdleTimerDisabled = false
+
+    var body: some View {
+        Form {
+            localInventorySection
+            nearbyDevicesSection
+
+            if let peer = selectedPeer {
+                selectedDeviceSection(peer)
+            }
+
+            if let progress = cacheSync.transferProgress,
+               progress.peerID == selectedPeerID {
+                transferProgressSection(progress)
+            }
+
+            if let completion = cacheSync.lastCompletion,
+               completion.peerID == selectedPeerID {
+                completionSection(completion)
+            }
+
+            if let error = cacheSync.lastError {
+                errorSection(error)
+            }
+        }
+        .navigationTitle(localized("cache_sync_title"))
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(cacheSync.operation == .transferring)
+        .interactiveDismissDisabled(cacheSync.operation == .transferring)
+        .onAppear(perform: startSession)
+        .onDisappear(perform: endSession)
+        .onChange(of: cacheSync.peers, initial: true) { _, peers in
+            updateSelection(for: peers)
+        }
+        .confirmationDialog(
+            localized("cache_sync_confirm_all_title"),
+            isPresented: $showsFullSyncConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(localized("cache_sync_sync_all")) {
+                startSync(maximumFileCount: nil)
+            }
+            Button(role: .cancel) {
+            } label: {
+                Text("cancel")
+            }
+        } message: {
+            Text(verbatim: fullSyncConfirmationMessage)
+        }
+    }
+
+    private var localInventorySection: some View {
+        Section {
+            LabeledContent {
+                if let inventory = cacheSync.localInventory {
+                    Text(verbatim: String(
+                        format: localized("cache_sync_inventory_format"),
+                        inventory.fileCount,
+                        byteString(inventory.byteCount)
+                    ))
+                    .monospacedDigit()
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            } label: {
+                Text(verbatim: localized("cache_sync_local_cache"))
+            }
+
+            LabeledContent {
+                Label {
+                    Text(verbatim: localized(
+                        cacheSync.isReceiving
+                            ? "cache_sync_receiver_ready"
+                            : "cache_sync_receiver_starting"
+                    ))
+                } icon: {
+                    Image(systemName: cacheSync.isReceiving
+                          ? "checkmark.circle.fill"
+                          : "clock.fill")
+                }
+                .foregroundStyle(cacheSync.isReceiving ? Color.green : Color.orange)
+            } label: {
+                Text(verbatim: localized("cache_sync_device_status"))
+            }
+        } header: {
+            Text(verbatim: localized("cache_sync_local_device"))
+        } footer: {
+            Text(verbatim: localized("cache_sync_local_network_footer"))
+        }
+    }
+
+    private var nearbyDevicesSection: some View {
+        Section {
+            if cacheSync.peers.isEmpty {
+                HStack(spacing: 10) {
+                    if cacheSync.isDiscovering {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "wifi.slash")
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(verbatim: localized(
+                        cacheSync.isDiscovering
+                            ? "cache_sync_searching_devices"
+                            : "cache_sync_no_devices"
+                    ))
+                    .foregroundStyle(.secondary)
+                }
+            } else {
+                ForEach(cacheSync.peers) { peer in
+                    peerRow(peer)
+                }
+            }
+
+            Button {
+                cacheSync.clearFeedback()
+                cacheSync.startDiscovery()
+            } label: {
+                Label {
+                    Text(verbatim: localized("cache_sync_refresh"))
+                } icon: {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            .disabled(cacheSync.operation == .transferring)
+        } header: {
+            Text(verbatim: localized("cache_sync_nearby_devices"))
+        } footer: {
+            Text(verbatim: localized("cache_sync_open_app_hint"))
+        }
+    }
+
+    private func peerRow(_ peer: AudioCacheSyncPeer) -> some View {
+        Button {
+            select(peer)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: peer.platform.symbolName)
+                    .font(.title3)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(verbatim: peer.name)
+                        .foregroundStyle(.primary)
+                    if let plan = cacheSync.peerPlans[peer.id] {
+                        Text(verbatim: planDescription(plan))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text(verbatim: localized("cache_sync_tap_to_compare"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                if cacheSync.operation == .inspecting,
+                   cacheSync.activePeerID == peer.id {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if selectedPeerID == peer.id {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(Color.accentColor)
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(cacheSync.operation == .transferring)
+    }
+
+    @ViewBuilder
+    private func selectedDeviceSection(_ peer: AudioCacheSyncPeer) -> some View {
+        Section {
+            if cacheSync.operation == .inspecting,
+               cacheSync.activePeerID == peer.id {
+                HStack(spacing: 10) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(verbatim: localized("cache_sync_comparing"))
+                }
+            } else if let plan = cacheSync.peerPlans[peer.id] {
+                LabeledContent {
+                    Text(verbatim: planDescription(plan))
+                        .multilineTextAlignment(.trailing)
+                } label: {
+                    Text(verbatim: localized("cache_sync_missing_on_target"))
+                }
+
+                if plan.missingFileCount > 0 {
+                    Button {
+                        startSync(maximumFileCount: 3)
+                    } label: {
+                        Label {
+                            Text(verbatim: localized("cache_sync_test_three"))
+                        } icon: {
+                            Image(systemName: "testtube.2")
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .disabled(cacheSync.operation != .idle)
+
+                    Button {
+                        showsFullSyncConfirmation = true
+                    } label: {
+                        Label {
+                            Text(verbatim: localized("cache_sync_sync_all"))
+                        } icon: {
+                            Image(systemName: "arrow.left.arrow.right.circle.fill")
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(cacheSync.operation != .idle)
+                } else {
+                    Label {
+                        Text(verbatim: localized("cache_sync_up_to_date"))
+                    } icon: {
+                        Image(systemName: "checkmark.circle.fill")
+                    }
+                    .foregroundStyle(.green)
+                }
+            } else {
+                Button {
+                    cacheSync.inspect(peerID: peer.id)
+                } label: {
+                    Text(verbatim: localized("cache_sync_tap_to_compare"))
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        } header: {
+            Text(verbatim: peer.name)
+        } footer: {
+            Text(verbatim: localized("cache_sync_test_three_footer"))
+        }
+    }
+
+    private func transferProgressSection(
+        _ progress: AudioCacheSyncTransferProgress
+    ) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(verbatim: progress.currentTitle
+                     ?? localized("cache_sync_preparing_transfer"))
+                    .lineLimit(2)
+
+                ProgressView(value: progress.fractionCompleted)
+
+                HStack {
+                    Text(verbatim: String(
+                        format: localized("cache_sync_progress_count_format"),
+                        progress.completedFileCount + progress.failedFileCount,
+                        progress.totalFileCount
+                    ))
+                    Spacer()
+                    Text(verbatim: "\(byteString(progress.sentByteCount)) / \(byteString(progress.totalByteCount))")
+                }
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+            }
+
+            Button(role: .destructive) {
+                cacheSync.cancelTransfer()
+            } label: {
+                Text(verbatim: localized("cache_sync_stop"))
+                    .frame(maxWidth: .infinity)
+            }
+        } header: {
+            Text(verbatim: localized("cache_sync_transferring"))
+        } footer: {
+            Text(verbatim: localized("cache_sync_keep_foreground"))
+        }
+    }
+
+    private func completionSection(
+        _ completion: AudioCacheSyncTransferCompletion
+    ) -> some View {
+        Section {
+            Label {
+                Text(verbatim: String(
+                    format: localized("cache_sync_completion_format"),
+                    completion.transferredFileCount,
+                    byteString(completion.transferredByteCount),
+                    completion.failedFileCount
+                ))
+            } icon: {
+                Image(systemName: completion.failedFileCount == 0
+                      ? "checkmark.circle.fill"
+                      : "exclamationmark.triangle.fill")
+            }
+            .foregroundStyle(
+                completion.failedFileCount == 0 ? Color.green : Color.orange
+            )
+
+            if !completion.transferredTitles.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(verbatim: localized("cache_sync_test_transferred_titles"))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    ForEach(
+                        Array(completion.transferredTitles.enumerated()),
+                        id: \.offset
+                    ) { _, title in
+                        Label {
+                            Text(verbatim: title)
+                                .lineLimit(2)
+                        } icon: {
+                            Image(systemName: "music.note")
+                        }
+                    }
+                }
+            }
+
+            Button {
+                cacheSync.clearFeedback()
+            } label: {
+                Text(verbatim: localized("cache_sync_done"))
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private func errorSection(_ message: String) -> some View {
+        Section {
+            Label {
+                Text(verbatim: message)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle.fill")
+            }
+            .foregroundStyle(.orange)
+
+            Button {
+                cacheSync.clearFeedback()
+                if let selectedPeerID {
+                    cacheSync.inspect(peerID: selectedPeerID)
+                } else {
+                    cacheSync.startDiscovery()
+                }
+            } label: {
+                Text(verbatim: localized("cache_sync_retry"))
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private var selectedPeer: AudioCacheSyncPeer? {
+        guard let selectedPeerID else { return nil }
+        return cacheSync.peers.first { $0.id == selectedPeerID }
+    }
+
+    private var selectedPlan: AudioCacheSyncPeerPlan? {
+        guard let selectedPeerID else { return nil }
+        return cacheSync.peerPlans[selectedPeerID]
+    }
+
+    private var fullSyncConfirmationMessage: String {
+        guard let plan = selectedPlan else {
+            return localized("cache_sync_select_device")
+        }
+        return String(
+            format: localized("cache_sync_confirm_all_message_format"),
+            plan.missingFileCount,
+            byteString(plan.missingByteCount)
+        )
+    }
+
+    private func startSession() {
+        previousIdleTimerDisabled = UIApplication.shared.isIdleTimerDisabled
+        UIApplication.shared.isIdleTimerDisabled = true
+        cacheSync.clearFeedback()
+        cacheSync.startDiscovery()
+        cacheSync.refreshLocalInventory()
+    }
+
+    private func endSession() {
+        if cacheSync.operation == .transferring {
+            cacheSync.cancelTransfer()
+        }
+        cacheSync.stopDiscovery()
+        UIApplication.shared.isIdleTimerDisabled = previousIdleTimerDisabled
+    }
+
+    private func updateSelection(for peers: [AudioCacheSyncPeer]) {
+        guard cacheSync.operation != .transferring else { return }
+        if let selectedPeerID,
+           peers.contains(where: { $0.id == selectedPeerID }) {
+            return
+        }
+        selectedPeerID = nil
+        let preferred = peers.first(where: { $0.platform.rawValue == "mac" })
+            ?? (peers.count == 1 ? peers[0] : nil)
+        if let preferred {
+            select(preferred)
+        }
+    }
+
+    private func select(_ peer: AudioCacheSyncPeer) {
+        guard cacheSync.operation != .transferring else { return }
+        selectedPeerID = peer.id
+        cacheSync.clearFeedback()
+        cacheSync.inspect(peerID: peer.id)
+    }
+
+    private func startSync(maximumFileCount: Int?) {
+        guard let selectedPeerID, cacheSync.operation == .idle else { return }
+        cacheSync.clearFeedback()
+        cacheSync.sync(
+            to: selectedPeerID,
+            maximumFileCount: maximumFileCount
+        )
+    }
+
+    private func planDescription(_ plan: AudioCacheSyncPeerPlan) -> String {
+        guard plan.missingFileCount > 0 else {
+            return plan.rejectedCount > 0
+                ? String(
+                    format: localized("cache_sync_up_to_date_skipped_format"),
+                    plan.rejectedCount
+                )
+                : localized("cache_sync_up_to_date")
+        }
+        var text = String(
+            format: localized("cache_sync_missing_format"),
+            plan.missingFileCount,
+            byteString(plan.missingByteCount)
+        )
+        if plan.rejectedCount > 0 {
+            text += " · " + String(
+                format: localized("cache_sync_skipped_format"),
+                plan.rejectedCount
+            )
+        }
+        return text
+    }
+
+    private func localized(_ key: String) -> String {
+        CacheSyncLocalization.text(key)
+    }
+
+    private func byteString(_ value: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: value, countStyle: .file)
+    }
+}
+
 private struct PlayerAppearanceSettingsView: View {
     @AppStorage(PlayerAppearancePreferences.animatedArtworkEnabledKey)
     private var animatedArtworkEnabled = PlayerAppearancePreferences.animatedArtworkEnabledByDefault

--- a/PrimuseTests/AudioCacheSyncPolicyTests.swift
+++ b/PrimuseTests/AudioCacheSyncPolicyTests.swift
@@ -55,4 +55,24 @@ final class AudioCacheSyncPolicyTests: XCTestCase {
             "source-id/hashed-name.m4a"
         )
     }
+
+    func testLimitedItemIDsKeepsDeterministicPrefix() {
+        let itemIDs = ["one", "two", "three", "four"]
+
+        XCTAssertEqual(
+            AudioCacheSyncPolicy.limitedItemIDs(itemIDs, maximumCount: 3),
+            ["one", "two", "three"]
+        )
+        XCTAssertEqual(
+            AudioCacheSyncPolicy.limitedItemIDs(itemIDs, maximumCount: 10),
+            itemIDs
+        )
+        XCTAssertEqual(
+            AudioCacheSyncPolicy.limitedItemIDs(itemIDs, maximumCount: nil),
+            itemIDs
+        )
+        XCTAssertTrue(
+            AudioCacheSyncPolicy.limitedItemIDs(itemIDs, maximumCount: 0).isEmpty
+        )
+    }
 }


### PR DESCRIPTION
## 背景

现有局域网缓存同步已经支持 Mac 向其他 Primuse 设备发送缓存，但 iPhone/iPad 目前只能作为接收端。若完整缓存只保留在移动端，用户无法在不重新访问媒体服务器的情况下恢复 Mac 缓存。

## 改动

- 在 iOS「设置 → 缓存同步」中增加发送入口
- 发现并选择附近的 Primuse 设备，比较目标端缺失缓存
- 增加“先试传最多 3 个文件”，并在完成后显示试传歌曲标题，便于先验证播放与服务端记录
- 增加全量同步确认，继续发送目标端缺失的全部缓存
- 试传结束后重新检查完整差异，显示剩余文件数量和体积
- 传输期间保持屏幕常亮，并提示两端保持前台
- 将缓存同步文案补齐至现有 7 种语言

## 实现说明

- 复用现有 `AudioCacheSyncService`、Bonjour 发现和端到端加密传输
- 限量试传先获取目标端完整缺失清单，再只构造最多 3 个缺失文件的传输清单
- 不修改同步协议版本、缓存格式或音乐源指纹规则
- 只读取发送端已经完整且通过大小校验的本地缓存；同步过程不会重新从媒体服务器下载音频
- 接收端仍按自己的曲库、音乐源 ID 和安全指纹解析目标路径，因此不会改变 Navidrome 歌曲身份或播放上报逻辑

## 验证

- iOS 与 macOS 条件编译语法检查通过
- 7 个本地化字符串表均通过 `plutil` 检查
- 7 种语言的键集合及 `%d` / `%@` 格式参数一致
- 新增限量清单策略单元测试
- `git diff --check` 通过

> 当前环境未安装完整 Xcode，因此尚未执行真机或完整 Xcode 构建；建议合并前由项目 CI/真机验证附近设备发现、3 文件试传以及后续全量同步。