### PR TITLE
在歌曲信息中展示 Navidrome 服务端播放次数

### DIFF
--- a/Primuse/Resources/de.lproj/Localizable.strings
+++ b/Primuse/Resources/de.lproj/Localizable.strings
@@ -2469,6 +2469,7 @@
 "songs_row_relaxed" = "Großzügig";
 "songs_column_format_sample_rate" = "Format / Abtastrate";
 "stats_play_count" = "Wiedergaben";
+"server_play_count_label" = "Server-Wiedergaben";
 "songs_column_rating" = "Bewertung";
 "songs_column_bitrate" = "Bitrate";
 "show_in_library" = "In Mediathek anzeigen";

--- a/Primuse/Resources/en.lproj/Localizable.strings
+++ b/Primuse/Resources/en.lproj/Localizable.strings
@@ -2287,6 +2287,7 @@
 "songs_row_relaxed" = "Relaxed";
 "songs_column_format_sample_rate" = "Format / Sample Rate";
 "stats_play_count" = "Play Count";
+"server_play_count_label" = "Server Play Count";
 "songs_column_rating" = "Rating";
 "songs_column_bitrate" = "Bit Rate";
 "show_in_library" = "Show in Library";

--- a/Primuse/Resources/fr.lproj/Localizable.strings
+++ b/Primuse/Resources/fr.lproj/Localizable.strings
@@ -2469,6 +2469,7 @@
 "songs_row_relaxed" = "Aérée";
 "songs_column_format_sample_rate" = "Format / Fréquence";
 "stats_play_count" = "Lectures";
+"server_play_count_label" = "Lectures sur le serveur";
 "songs_column_rating" = "Note";
 "songs_column_bitrate" = "Débit";
 "show_in_library" = "Afficher dans la bibliothèque";

--- a/Primuse/Resources/ja.lproj/Localizable.strings
+++ b/Primuse/Resources/ja.lproj/Localizable.strings
@@ -2470,6 +2470,7 @@
 "songs_row_relaxed" = "ゆったり";
 "songs_column_format_sample_rate" = "形式 / サンプルレート";
 "stats_play_count" = "再生回数";
+"server_play_count_label" = "サーバー再生回数";
 "songs_column_rating" = "評価";
 "songs_column_bitrate" = "ビットレート";
 "show_in_library" = "ライブラリで表示";

--- a/Primuse/Resources/ko.lproj/Localizable.strings
+++ b/Primuse/Resources/ko.lproj/Localizable.strings
@@ -2469,6 +2469,7 @@
 "songs_row_relaxed" = "넓게";
 "songs_column_format_sample_rate" = "포맷 / 샘플 레이트";
 "stats_play_count" = "재생 횟수";
+"server_play_count_label" = "서버 재생 횟수";
 "songs_column_rating" = "평점";
 "songs_column_bitrate" = "비트레이트";
 "show_in_library" = "보관함에서 보기";

--- a/Primuse/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Primuse/Resources/zh-Hans.lproj/Localizable.strings
@@ -2562,6 +2562,7 @@
 "songs_row_relaxed" = "宽松";
 "songs_column_format_sample_rate" = "格式 / 采样率";
 "stats_play_count" = "播放次数";
+"server_play_count_label" = "服务端播放次数";
 "songs_column_rating" = "评分";
 "songs_column_bitrate" = "比特率";
 "show_in_library" = "在资料库中显示";

--- a/Primuse/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Primuse/Resources/zh-Hant.lproj/Localizable.strings
@@ -2446,6 +2446,7 @@
 "songs_row_relaxed" = "寬鬆";
 "songs_column_format_sample_rate" = "格式 / 取樣率";
 "stats_play_count" = "播放次數";
+"server_play_count_label" = "伺服器播放次數";
 "songs_column_rating" = "評分";
 "songs_column_bitrate" = "位元率";
 "show_in_library" = "在資料庫中顯示";

--- a/Primuse/Services/Library/LibraryDatabase.swift
+++ b/Primuse/Services/Library/LibraryDatabase.swift
@@ -278,6 +278,15 @@ actor LibraryDatabase {
             }
         }
 
+        // Account-scoped play count reported by Navidrome/Subsonic. Nil keeps
+        // local files and servers that omit `playCount` distinguishable from a
+        // real server value of zero.
+        migrator.registerMigration("v14_song_server_play_count") { db in
+            try db.alter(table: "songs") { t in
+                t.add(column: "serverPlayCount", .integer)
+            }
+        }
+
         // Run every registered migration, not just v1 — pinning to
         // `upTo: "v1_initial"` would silently skip later versions on
         // upgrade and reintroduce schema drift.

--- a/Primuse/Services/Library/MetadataBackfillService.swift
+++ b/Primuse/Services/Library/MetadataBackfillService.swift
@@ -3673,6 +3673,7 @@ final class MetadataBackfillService {
             year: metadata.year ?? bare.year,
             lastModified: bare.lastModified,
             dateAdded: bare.dateAdded,
+            serverPlayCount: bare.serverPlayCount,
             coverArtFileName: coverRef,
             artistArtworkFileName: bare.artistArtworkFileName,
             lyricsFileName: lyricsRef,

--- a/Primuse/Services/Library/MusicLibrary.swift
+++ b/Primuse/Services/Library/MusicLibrary.swift
@@ -3631,6 +3631,7 @@ final class MusicLibrary {
                     if newSong.dateAdded < merged.dateAdded {
                         merged.dateAdded = newSong.dateAdded
                     }
+                    merged.serverPlayCount = newSong.serverPlayCount
                     // Always refresh revision — when the connector starts
                     // surfacing a fingerprint that wasn't there before
                     // (e.g. user upgraded to a build that reads md5), we

--- a/Primuse/Services/Sources/SubsonicSource.swift
+++ b/Primuse/Services/Sources/SubsonicSource.swift
@@ -1188,6 +1188,7 @@ actor SubsonicSource: RefreshingMetadataSongConnector, ServerScrobblingConnector
             genre: child.genre,
             year: child.year,
             lastModified: child.created.flatMap(Self.parseDate),
+            serverPlayCount: child.playCount,
             coverArtFileName: coverArtID.flatMap { coverArtURLString(for: $0) },
             artistArtworkFileName: (child.artists?.first?.id ?? child.artistId)
                 .flatMap { artistArtworkReference(for: $0) }

--- a/Primuse/Views/NowPlaying/NowPlayingView.swift
+++ b/Primuse/Views/NowPlaying/NowPlayingView.swift
@@ -4252,6 +4252,12 @@ struct SongInfoSheet: View {
                 }
 
                 Section(String(localized: "library_info")) {
+                    if let serverPlayCount = song.serverPlayCount {
+                        infoRow(
+                            String(localized: "server_play_count_label"),
+                            serverPlayCount.formatted()
+                        )
+                    }
                     infoRow(String(localized: "date_added_label"), song.dateAdded.formatted(date: .long, time: .omitted))
                     if let lastModified = song.lastModified {
                         infoRow(String(localized: "last_modified_label"), lastModified.formatted(date: .abbreviated, time: .shortened))
@@ -4444,6 +4450,9 @@ struct SongInfoSheet: View {
         if let track = song.trackNumber { rows.append((String(localized: "track_label"), "\(track)", false)) }
         rows.append((String(localized: "stats_play_count"), playbackStats.playCount.formatted(), false))
         rows.append((String(localized: "last_played_label"), playbackStats.lastPlayedAt?.formatted(date: .abbreviated, time: .shortened) ?? String(localized: "no_recorded_playback"), false))
+        if let serverPlayCount = song.serverPlayCount {
+            rows.append((String(localized: "server_play_count_label"), serverPlayCount.formatted(), false))
+        }
         rows.append((String(localized: "date_added_label"), song.dateAdded.formatted(date: .long, time: .omitted), false))
         if let lastModified = song.lastModified {
             rows.append((String(localized: "last_modified_label"), lastModified.formatted(date: .abbreviated, time: .shortened), false))

--- a/PrimuseKit/Sources/PrimuseKit/Models/Song.swift
+++ b/PrimuseKit/Sources/PrimuseKit/Models/Song.swift
@@ -34,6 +34,10 @@ public struct Song: Codable, Identifiable, Hashable, Sendable {
     public var year: Int?
     public var lastModified: Date?
     public var dateAdded: Date
+    /// Play count reported by the authenticated media-server account during
+    /// the latest catalogue refresh. This is intentionally separate from the
+    /// on-device history maintained by Primuse's `PlayHistoryStore`.
+    public var serverPlayCount: Int?
     public var coverArtFileName: String?
     /// Source-owned artist artwork reference captured from a server catalogue.
     /// Unlike `artistID`, which is replaced with Primuse's name-derived ID,
@@ -100,6 +104,7 @@ public struct Song: Codable, Identifiable, Hashable, Sendable {
         year: Int? = nil,
         lastModified: Date? = nil,
         dateAdded: Date = Date(),
+        serverPlayCount: Int? = nil,
         coverArtFileName: String? = nil,
         artistArtworkFileName: String? = nil,
         lyricsFileName: String? = nil,
@@ -140,6 +145,7 @@ public struct Song: Codable, Identifiable, Hashable, Sendable {
         self.year = year
         self.lastModified = lastModified
         self.dateAdded = dateAdded
+        self.serverPlayCount = serverPlayCount
         self.coverArtFileName = coverArtFileName
         self.artistArtworkFileName = artistArtworkFileName
         self.lyricsFileName = lyricsFileName

--- a/PrimuseKit/Sources/PrimuseKit/SourceCatalogSnapshotPolicy.swift
+++ b/PrimuseKit/Sources/PrimuseKit/SourceCatalogSnapshotPolicy.swift
@@ -157,6 +157,10 @@ public enum ServerSongCatalogMergePolicy {
         if refreshed.bitDepth == nil { refreshed.bitDepth = incoming.bitDepth }
         if refreshed.revision == nil { refreshed.revision = incoming.revision }
         if refreshed.lastModified == nil { refreshed.lastModified = incoming.lastModified }
+        // Account-scoped server statistics can change while the media object
+        // itself remains byte-for-byte identical. Always adopt the latest
+        // catalogue value instead of treating it as device enrichment.
+        refreshed.serverPlayCount = incoming.serverPlayCount
         if !incoming.filePath.isEmpty { refreshed.filePath = incoming.filePath }
         if refreshed.coverArtFileName == nil {
             refreshed.coverArtFileName = incoming.coverArtFileName

--- a/PrimuseKit/Tests/PrimuseKitTests/SourceCatalogSnapshotPolicyTests.swift
+++ b/PrimuseKit/Tests/PrimuseKitTests/SourceCatalogSnapshotPolicyTests.swift
@@ -179,6 +179,22 @@ struct ServerSongCatalogMergePolicyTests {
         #expect(merged.replayGainTrackGain == existing.replayGainTrackGain)
     }
 
+    @Test func stableServerRowsRefreshAccountPlayCount() {
+        var existing = song(revision: "r1")
+        existing.serverPlayCount = 12
+        existing.lyricsText = "locally indexed lyrics"
+        var incoming = song(revision: "r1")
+        incoming.serverPlayCount = 19
+
+        let merged = ServerSongCatalogMergePolicy.merged(
+            existing: existing,
+            incoming: incoming
+        )
+
+        #expect(merged.serverPlayCount == 19)
+        #expect(merged.lyricsText == existing.lyricsText)
+    }
+
     @Test func formatAndCueBoundaryChangesAreContentReplacements() {
         let existing = song(revision: "r1")
         var changedFormat = existing

--- a/PrimuseTests/SubsonicFavoriteWritebackTests.swift
+++ b/PrimuseTests/SubsonicFavoriteWritebackTests.swift
@@ -515,6 +515,7 @@ final class SubsonicServerScanTests: XCTestCase {
         let final = try await source.songCatalogPage(from: "/", offset: 500)
         XCTAssertEqual(final.itemIDs, ["song-500"])
         XCTAssertEqual(final.songs.map(\.song.filePath), ["/songs/song-500.mp3"])
+        XCTAssertEqual(final.songs.map(\.song.serverPlayCount), [500])
         XCTAssertNil(final.nextOffset)
 
         let offsets: [String] = SubsonicServerScanURLProtocol.requests(host: host).compactMap { request -> String? in
@@ -639,7 +640,7 @@ private final class SubsonicServerScanURLProtocol: URLProtocol, @unchecked Senda
                 .flatMap(Int.init) ?? 0
             let range = offset == 0 ? 0..<500 : 500..<501
             let songs = range.map { index in
-                #"{"id":"song-\#(index)","title":"Song \#(index)","suffix":"mp3","path":"Artist/Album/Song \#(index).mp3","size":1024,"duration":180}"#
+                #"{"id":"song-\#(index)","title":"Song \#(index)","suffix":"mp3","path":"Artist/Album/Song \#(index).mp3","size":1024,"duration":180,"playCount":\#(index)}"#
             }.joined(separator: ",")
             respond(json: #"{"subsonic-response":{"status":"ok","searchResult3":{"song":[\#(songs)]}}}"#)
             return


### PR DESCRIPTION
## 背景

歌曲信息中“播放记录”的“播放次数”来自 Primuse 本地的 `PlayHistoryStore`；Navidrome 返回的 `playCount` 则属于当前登录用户的服务端统计。两者语义不同，现有界面没有展示后者。

## 改动

- 将 Subsonic / OpenSubsonic `Child.playCount` 映射为独立的 `Song.serverPlayCount`，并通过数据库迁移持久化
- 在稳定目录合并时刷新服务端播放次数，同时保留本机歌词、拼音、ReplayGain 等增强数据
- 在歌曲信息的“资料库”区域新增“服务端播放次数”；原“播放记录”中的 Primuse 本地次数保持不变
- 服务端缺少 `playCount` 时不显示该行；服务端明确返回 `0` 时正常显示 0，避免把“不支持”误当成“从未播放”
- 同步支持 iOS / iPadOS 与 macOS，并补齐 7 种本地化

接口字段参考：[OpenSubsonic Child.playCount](https://opensubsonic.netlify.app/docs/responses/child/)。该值会在媒体源资料库刷新/扫描时更新。

## 验证

- `swift build --package-path PrimuseKit` 通过
- 改动涉及的 Swift 文件语法检查通过
- 7 种 `Localizable.strings` 格式与键覆盖检查通过
- 新增回归测试，覆盖 Navidrome `playCount` 映射及稳定曲目合并时的次数刷新

> 当前机器只有 Command Line Tools、没有完整 Xcode，无法运行依赖 Apple Testing 模块的完整测试目标。